### PR TITLE
Add deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build.prod": "gulp build.prod --color",
     "build.test": "gulp build.test --color",
     "build.test.watch": "gulp build.test.watch --color",
+    "deploy": "aws --profile geodesy s3 sync dist/prod s3://gnss-site-manager --acl public-read",
     "generate.manifest": "gulp generate.manifest --color",
     "e2e": "protractor",
     "e2e.live": "protractor --elementExplorer",


### PR DESCRIPTION
Install and configure awcli and run "npm run-script deploy". The
application is deployed to gnss-site-manager.s3-website-ap-southeast-2.amazonaws.com.