### PR TITLE
Fix bug introduced last commit

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -10,7 +10,6 @@ import { loadTasks } from './tools/utils';
 loadTasks(SEED_TASKS_DIR);
 loadTasks(PROJECT_TASKS_DIR);
 
-let debug=argv.debug;
 // --------------
 // Build dev.
 gulp.task('build.dev', (done: any) => {


### PR DESCRIPTION
* Also worked out that if you have a gulpfile.js then
all gulp related files need to be .js format, including
tools/task/projet.  But the .ts we have aren't transpilled.
* HOWEVER if only a gulpfile.ts exists then only *.ts
gulpfiles (eg. tools/tasks/{project,seed}) are used