### PR TITLE
Including ogc-schemas with Jsonix for ogc and geodesy

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,14 +123,15 @@
     "@angular/platform-browser": "2.0.0-rc.5",
     "@angular/platform-browser-dynamic": "2.0.0-rc.5",
     "@angular/router": "3.0.0-rc.1",
-    "es6-module-loader": "^0.17.8",
+    "bootstrap": "3.3.7",
     "core-js": "^2.4.0",
+    "es6-module-loader": "^0.17.8",
+    "moment": "^2.14.1",
+    "ng2-bootstrap": "^1.0.24",
+    "ng2-table": "^1.0.2",
+    "ogc-schemas": "file:ogc-schemas-2.6.2-SNAPSHOT.tgz",
     "rxjs": "5.0.0-beta.6",
     "systemjs": "0.19.27",
-    "zone.js": "^0.6.12",
-    "bootstrap": "3.3.7",
-    "ng2-table": "^1.0.2",
-    "ng2-bootstrap": "^1.0.24",
-    "moment": "^2.14.1"
+    "zone.js": "^0.6.12"
   }
 }


### PR DESCRIPTION
* Work-around to a problem by committing this directly to
this repo as a .tar.gz
* Problem is that we tried putting this in our nexus repo.
So we need to setup a different npm registry.  We need npm scopes
to differentiate between this and standard npm registry.
However nexus npm doesn't seem to support '@' scopes