### PR TITLE
Fix ng2-bootstrap new ver 1.1.0 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "zone.js": "^0.6.12",
     "bootstrap": "3.3.7",
     "ng2-table": "^1.0.2",
-    "ng2-bootstrap": "^1.0.24",
+    "ng2-bootstrap": "~1.0.24",
     "moment": "^2.14.1"
   }
 }


### PR DESCRIPTION
* This has dependencies that don't seem to be compatible

The problem is that in the `package.json`, it specified

    "ng2-bootstrap": "^1.0.24"

With the `^` meaning "At least this version and any new MINOR or BUG versions available".

However, the just-released 1.1.0 has breaking changes.  It incorporated NG2 rc.5 ngModule changes that are substantially architecturally different.  I'm thinking the version should have been 2.0.0.

Changed to:

    "ng2-bootstrap": "~1.0.24"

Which fixes to the minor version but will take in any new bug fixes.