### PR TITLE
Smaller width css

### DIFF
--- a/src/client/app/+select-site/select-site.component.html
+++ b/src/client/app/+select-site/select-site.component.html
@@ -1,4 +1,4 @@
-<div class="col-md-12 col-sm-12 col-xs-12 pad-sm">
+<div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12 pad-sm">
   <div class="panel-group">
     <div class="panel panel-info">
       <div class="panel-heading">
@@ -12,21 +12,21 @@
       <div class="panel-body">
         <form name="searchSite" novalidate class="form-horizontal">
           <div class="form-group">
-            <label class="col-md-4 col-sm-4 col-xs-12 control-label">Four Character Id</label>
-            <div class="col-md-4 col-sm-5 col-xs-12">
+            <label class="col-md-4 col-sm-4 col-xs-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
+            <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
               <input type="text" maxlength="9" class="form-control" name="fourCharacterId"
                      placeholder="Search by Four Character Id" [(ngModel)]="fourCharacterId"/>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-md-4 col-sm-4 col-xs-12 control-label">Site Name</label>
-            <div class="col-md-4 col-sm-5 col-xs-12">
+            <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Site Name</label>
+            <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
               <input type="text" maxlength="200" class="form-control" name="siteName"
                      placeholder="Search by Site Name" [(ngModel)]="siteName"/>
             </div>
           </div>
           <div class="form-group">
-            <div class="col-md-12 col-sm-12 col-xs-12">
+            <div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12">
               <div class="align-center">
                 <button class="btn btn-primary margin10" type="submit" (click)="searchSites()" title="Search desired CORS sites">Search</button>
                 <button class="btn btn-primary margin10" type="submit" (click)="clearAll()" title="Clear all inputs and search results if any">Clear All</button>

--- a/src/client/app/+select-site/select-site.component.html
+++ b/src/client/app/+select-site/select-site.component.html
@@ -12,14 +12,14 @@
       <div class="panel-body">
         <form name="searchSite" novalidate class="form-horizontal">
           <div class="form-group">
-            <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
+            <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Four Character Id</label>
             <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
               <input type="text" maxlength="9" class="form-control" name="fourCharacterId"
                      placeholder="Search by Four Character Id" [(ngModel)]="fourCharacterId"/>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Site Name</label>
+            <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Site Name</label>
             <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
               <input type="text" maxlength="200" class="form-control" name="siteName"
                      placeholder="Search by Site Name" [(ngModel)]="siteName"/>

--- a/src/client/app/+select-site/select-site.component.html
+++ b/src/client/app/+select-site/select-site.component.html
@@ -12,7 +12,7 @@
       <div class="panel-body">
         <form name="searchSite" novalidate class="form-horizontal">
           <div class="form-group">
-            <label class="col-md-4 col-sm-4 col-xs-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
+            <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
             <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
               <input type="text" maxlength="9" class="form-control" name="fourCharacterId"
                      placeholder="Search by Four Character Id" [(ngModel)]="fourCharacterId"/>
@@ -53,12 +53,14 @@
             <table class="table table-striped table-hover" style="width: 100%;" role="grid">
               <thead>
               <tr role="row">
-                <th name="column_1" (click)="sortField(0)">
+                <th name="column_1" (click)="sortField(0)"
+                    title="Click to sort Four Character Id in {{ ( !columns[0].sort || columns[0].sort == 'asc' ) ? 'ascending' : 'descending'}} order">
                   Four Character ID
                   <i *ngIf="columns[0].sort == 'asc'" class="glyphicon glyphicon-chevron-up"></i>
                   <i *ngIf="columns[0].sort == 'desc'" class="glyphicon glyphicon-chevron-down"></i>
                 </th>
-                <th name="column_2" (click)="sortField(1)">
+                <th name="column_2" (click)="sortField(1)"
+                    title="Click to sort Site Name in {{ ( !columns[1].sort || columns[1].sort == 'asc' ) ? 'ascending' : 'descending'}} order">
                   Site Name
                   <i *ngIf="columns[1].sort == 'asc'" class="glyphicon glyphicon-chevron-up"></i>
                   <i *ngIf="columns[1].sort == 'desc'" class="glyphicon glyphicon-chevron-down"></i>

--- a/src/client/app/+site-info/site-info.component.html
+++ b/src/client/app/+site-info/site-info.component.html
@@ -19,14 +19,14 @@
           </div>
           <div *ngIf=" site != null ">
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
+              <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Four Character Id</label>
               <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="9" class="form-control"
                        name="site.fourCharacterId" [(ngModel)]="site.fourCharacterId"/>
               </div>
             </div>
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Site Name</label>
+              <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Site Name</label>
               <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="100" class="form-control"
                        name="site.name" [(ngModel)]="site.name"/>
@@ -34,7 +34,7 @@
             </div>
             <div *ngIf="siteLocation !=null">
               <div class="form-group">
-                <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">City / Town</label>
+                <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">City / Town</label>
                 <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                   <input type="text" maxlength="100" class="form-control"
                          name="siteLocation.city" [(ngModel)]="siteLocation.city"/>
@@ -42,7 +42,7 @@
               </div>
             </div>
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">IERS DOMES Number </label>
+              <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">IERS DOMES Number </label>
               <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="100" class="form-control"
                        name="site.domesNumber" [(ngModel)]="site.domesNumber"/>
@@ -79,28 +79,28 @@
             <div class="panel-body" *ngIf="status.isSiteOwnerOpen">
               <div *ngIf="siteOwner != null">
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Full Name</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Full Name</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.name" [(ngModel)]="siteOwner.individualName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Organisation</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Organisation</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.organisation" [(ngModel)]="siteOwner.organisationName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Position</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Position</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.position" [(ngModel)]="siteOwner.positionName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Address</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Address</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.address" [(ngModel)]="siteOwner.contactInfo.address"/>
@@ -108,7 +108,7 @@
                 </div>
                 <div *ngFor="let ph of siteOwner.contactInfo.phone.voices; let i = index">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Phone {{i+1}}</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Phone {{i+1}}</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="site.owner.phone" [(ngModel)]="siteOwner.contactInfo.phone.voices[i]"/>
@@ -130,21 +130,21 @@
             <div class="panel-body" *ngIf="status.isMetaCustodianOpen">
               <div *ngIf="metadataCustodian != null">
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Full Name</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Full Name</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.name" [(ngModel)]="metadataCustodian.individualName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Organisation</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Organisation</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.organisation" [(ngModel)]="metadataCustodian.organisationName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Position</label>
+                  <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Position</label>
                   <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.position" [(ngModel)]="metadataCustodian.positionName"/>
@@ -202,21 +202,21 @@
                 </div>
                 <div *ngIf=" receiver != null ">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Type</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Type</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.type_{{i}}" [(ngModel)]="receiver.id.type"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Serial Number</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Serial Number</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.serialNumber_{{i}}" [(ngModel)]="receiver.id.serialNumber"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Firmware Version</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Firmware Version</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.firmwareVersion_{{i}}"
@@ -224,7 +224,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Satellite System</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Satellite System</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.satelliteSystem_{{i}}"
@@ -232,7 +232,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Elevation Cutoff Setting</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Elevation Cutoff Setting</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.elevetionCutoffSetting_{{i}}"
@@ -240,14 +240,14 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Installed</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Date Installed</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.dateInstalled_{{i}}" [(ngModel)]="receiver.period.from"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Removed</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Date Removed</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.dateRemoved_{{i}}" [(ngModel)]="receiver.period.to"/>
@@ -305,21 +305,21 @@
                 </div>
                 <div *ngIf=" antenna != null ">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Type</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Antenna Type</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.type_{{i}}" [(ngModel)]="antenna.id.type"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Serial Number</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Serial Number</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.serialNumber_{{i}}" [(ngModel)]="antenna.id.serialNumber"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Reference Point</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Antenna Reference Point</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaReferencePoint_{{i}}"
@@ -327,7 +327,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP Up Eccentricity</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Marker ARP Up Eccentricity</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpUpEccentricity_{{i}}"
@@ -335,7 +335,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP North Eccentricity</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Marker ARP North Eccentricity</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpNorthEccentricity_{{i}}"
@@ -343,7 +343,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP East Eccentricity</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Marker ARP East Eccentricity</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpEastEccentricity_{{i}}"
@@ -351,7 +351,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Alignment From True North</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Alignment From True North</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.alignmentFromTrueNorth_{{i}}"
@@ -359,14 +359,14 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Radome Type</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Radome Type</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.radomeType_{{i}}" [(ngModel)]="antenna.configuration.radomeType"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Radome Serial Number</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Radome Serial Number</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.radomeSerialNumber_{{i}}"
@@ -374,7 +374,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Cable Type</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Antenna Cable Type</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaCableType_{{i}}"
@@ -382,7 +382,7 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Cable Length</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Antenna Cable Length</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaCableLength_{{i}}"
@@ -390,14 +390,14 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Installed</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Date Installed</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.dateInstalled_{{i}}" [(ngModel)]="antenna.period.from"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Removed</label>
+                    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Date Removed</label>
                     <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.dateRemoved_{{i}}" [(ngModel)]="antenna.period.to"/>

--- a/src/client/app/+site-info/site-info.component.html
+++ b/src/client/app/+site-info/site-info.component.html
@@ -1,4 +1,4 @@
-<div class="col-md-12 col-sm-12 col-xs-12 pad-sm">
+<div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12 pad-sm">
   <form name="siteInfo" novalidate class="form-horizontal">
     <div class="panel-group">
       <div class="panel panel-info">
@@ -19,31 +19,31 @@
           </div>
           <div *ngIf=" site != null ">
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-12 control-label">Four Character Id</label>
-              <div class="col-md-4 col-sm-5 col-xs-12">
+              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Four Character Id</label>
+              <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="9" class="form-control"
                        name="site.fourCharacterId" [(ngModel)]="site.fourCharacterId"/>
               </div>
             </div>
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-12 control-label">Site Name</label>
-              <div class="col-md-4 col-sm-5 col-xs-12">
+              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Site Name</label>
+              <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="100" class="form-control"
                        name="site.name" [(ngModel)]="site.name"/>
               </div>
             </div>
             <div *ngIf="siteLocation !=null">
               <div class="form-group">
-                <label class="col-md-4 col-sm-4 col-xs-12 control-label">City / Town</label>
-                <div class="col-md-4 col-sm-5 col-xs-12">
+                <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">City / Town</label>
+                <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                   <input type="text" maxlength="100" class="form-control"
                          name="siteLocation.city" [(ngModel)]="siteLocation.city"/>
                 </div>
               </div>
             </div>
             <div class="form-group">
-              <label class="col-md-4 col-sm-4 col-xs-12 control-label">IERS DOMES Number </label>
-              <div class="col-md-4 col-sm-5 col-xs-12">
+              <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">IERS DOMES Number </label>
+              <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                 <input type="text" maxlength="100" class="form-control"
                        name="site.domesNumber" [(ngModel)]="site.domesNumber"/>
               </div>
@@ -60,10 +60,10 @@
             </div>
             <div class="panel-body" *ngIf="status.isSiteMediaOpen">
               <div class="form-group">
-                <label class="col-md-4 col-sm-4 col-xs-12 control-label">View PDFs </label>
+                <label class="col-md-4 col-sm-4 col-xs-12 col-xxs-12 control-label">View PDFs </label>
               </div>
               <div class="form-group">
-                <label class="col-md-4 col-sm-4 col-xs-12 control-label">View Photos</label>
+                <label class="col-md-4 col-sm-4 col-xs-12 col-xxs-12 control-label">View Photos</label>
               </div>
             </div>
           </div>-->
@@ -79,37 +79,37 @@
             <div class="panel-body" *ngIf="status.isSiteOwnerOpen">
               <div *ngIf="siteOwner != null">
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Full Name</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Full Name</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.name" [(ngModel)]="siteOwner.individualName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Organisation</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Organisation</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.organisation" [(ngModel)]="siteOwner.organisationName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Position</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Position</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.position" [(ngModel)]="siteOwner.positionName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Address</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Address</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.owner.address" [(ngModel)]="siteOwner.contactInfo.address"/>
                   </div>
                 </div>
                 <div *ngFor="let ph of siteOwner.contactInfo.phone.voices; let i = index">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Phone {{i+1}}</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Phone {{i+1}}</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="site.owner.phone" [(ngModel)]="siteOwner.contactInfo.phone.voices[i]"/>
                     </div>
@@ -130,22 +130,22 @@
             <div class="panel-body" *ngIf="status.isMetaCustodianOpen">
               <div *ngIf="metadataCustodian != null">
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Full Name</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Full Name</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.name" [(ngModel)]="metadataCustodian.individualName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Organisation</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Organisation</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.organisation" [(ngModel)]="metadataCustodian.organisationName"/>
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-4 col-sm-4 col-xs-12 control-label">Position</label>
-                  <div class="col-md-4 col-sm-5 col-xs-12">
+                  <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Position</label>
+                  <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                     <input type="text" maxlength="100" class="form-control"
                            name="site.metadataCustodian.position" [(ngModel)]="metadataCustodian.positionName"/>
                   </div>
@@ -202,53 +202,53 @@
                 </div>
                 <div *ngIf=" receiver != null ">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Type</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Type</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.type_{{i}}" [(ngModel)]="receiver.id.type"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Serial Number</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Serial Number</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.serialNumber_{{i}}" [(ngModel)]="receiver.id.serialNumber"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Firmware Version</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Firmware Version</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.firmwareVersion_{{i}}"
                              [(ngModel)]="receiver.configuration.firmwareVersion"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Satellite System</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Satellite System</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.satelliteSystem_{{i}}"
                              [(ngModel)]="receiver.configuration.satelliteSystem"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Elevation Cutoff Setting</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Elevation Cutoff Setting</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.elevetionCutoffSetting_{{i}}"
                              [(ngModel)]="receiver.configuration.elevetionCutoffSetting"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Date Installed</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Installed</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.dateInstalled_{{i}}" [(ngModel)]="receiver.period.from"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Date Removed</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Removed</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="receiver.dateRemoved_{{i}}" [(ngModel)]="receiver.period.to"/>
                     </div>
@@ -305,100 +305,100 @@
                 </div>
                 <div *ngIf=" antenna != null ">
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Antenna Type</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Type</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.type_{{i}}" [(ngModel)]="antenna.id.type"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Serial Number</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Serial Number</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.serialNumber_{{i}}" [(ngModel)]="antenna.id.serialNumber"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Antenna Reference Point</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Reference Point</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaReferencePoint_{{i}}"
                              [(ngModel)]="antenna.configuration.antennaReferencePoint"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Marker ARP Up Eccentricity</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP Up Eccentricity</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpUpEccentricity_{{i}}"
                              [(ngModel)]="antenna.configuration.markerArpUpEccentricity"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Marker ARP North Eccentricity</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP North Eccentricity</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpNorthEccentricity_{{i}}"
                              [(ngModel)]="antenna.configuration.markerArpNorthEccentricity"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Marker ARP East Eccentricity</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Marker ARP East Eccentricity</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.markerArpEastEccentricity_{{i}}"
                              [(ngModel)]="antenna.configuration.markerArpEastEccentricity"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Alignment From True North</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Alignment From True North</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.alignmentFromTrueNorth_{{i}}"
                              [(ngModel)]="antenna.configuration.alignmentFromTrueNorth"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Radome Type</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Radome Type</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.radomeType_{{i}}" [(ngModel)]="antenna.configuration.radomeType"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Radome Serial Number</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Radome Serial Number</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.radomeSerialNumber_{{i}}"
                              [(ngModel)]="antenna.configuration.radomSerialNumber"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Antenna Cable Type</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Cable Type</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaCableType_{{i}}"
                              [(ngModel)]="antenna.configuration.antennaCableType"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Antenna Cable Length</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Antenna Cable Length</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.antennaCableLength_{{i}}"
                              [(ngModel)]="antenna.configuration.antennaCableLength"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Date Installed</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Installed</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.dateInstalled_{{i}}" [(ngModel)]="antenna.period.from"/>
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-4 col-sm-4 col-xs-12 control-label">Date Removed</label>
-                    <div class="col-md-4 col-sm-5 col-xs-12">
+                    <label class="col-md-4 col-sm-4 col-xs-4 col-xxs-12 control-label">Date Removed</label>
+                    <div class="col-md-4 col-sm-5 col-xs-7 col-xxs-12">
                       <input type="text" maxlength="100" class="form-control"
                              name="antenna.dateRemoved_{{i}}" [(ngModel)]="antenna.period.to"/>
                     </div>
@@ -412,9 +412,9 @@
     </div>
 
     <div class="form-group">
-      <div class="col-md-12 col-sm-12 col-xs-12">
+      <div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12">
         <div class="align-center">
-          <button class="btn btn-primary margin10" type="submit" (click)="save()" disabled="true"
+          <button class="btn btn-primary margin10-first" type="submit" (click)="save()" disabled="true"
                   title="Save changes made if any">Save
           </button>
           <button class="btn btn-primary margin10" type="submit" (click)="loadSiteInfoData()"

--- a/src/client/app/shared/toolbar/toolbar.component.css
+++ b/src/client/app/shared/toolbar/toolbar.component.css
@@ -37,8 +37,9 @@
 
 .dropdown-menu > li > a:focus,
 .dropdown-menu > li > a:hover {
-    background-color: #d0f9b6 !important;
-    cursor: pointer;
+  background-color: #e5f5e0;
+  color: #2a2aff;
+  cursor: pointer;
 }
 
 #clear {

--- a/src/client/app/shared/toolbar/toolbar.component.css
+++ b/src/client/app/shared/toolbar/toolbar.component.css
@@ -16,7 +16,7 @@
 }
 
 .menu-btn {
-  background-color: #106cc8;
+  background-color: transparent;
   color: #fff;
   font-size: 18px !important;
   font-weight: 400 !important;
@@ -35,8 +35,14 @@
   padding-left: 5px;
 }
 
+.dropdown-menu > li > a:focus,
+.dropdown-menu > li > a:hover {
+    background-color: #d0f9b6 !important;
+    cursor: pointer;
+}
+
 #clear {
-  background-color: #106cc8;
+  background-color: transparent;
   float: right;
   margin-top: 35px;
   border: 1px solid rgb(255, 255, 255);

--- a/src/client/app/shared/toolbar/toolbar.component.html
+++ b/src/client/app/shared/toolbar/toolbar.component.html
@@ -4,8 +4,8 @@
       <i class="glyphicon glyphicon-menu-hamburger"></i>
     </button>
     <ul dropdownMenu role="menu" aria-labelledby="menu-button">
-      <li role="menuitem"><a class="dropdown-item" [routerLink]="['/']">Select Site</a></li>
-      <li role="menuitem"><a class="dropdown-item" [routerLink]="['/about']">About</a></li>
+      <li role="menuitem"><a [routerLink]="['/']">Select Site</a></li>
+      <li role="menuitem"><a [routerLink]="['/about']">About</a></li>
       <li class="divider dropdown-divider"></li>
       <li role="menuitem"><a (click)="clearCache()">Update Application</a></li>
     </ul>

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -57,10 +57,10 @@ body {
   padding-right: 5px;
 }
 
-.table-hover tbody tr:hover > td,
-.table-hover tbody tr:hover > th {
-  background-color: #d0f9b6 !important;
+.table-hover tbody tr:hover > td {
+  background-color: #e5f5e0 !important;
   color: #2a2aff;
+  cursor: pointer;
 }
 
 .tips {

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -27,7 +27,7 @@ body {
 .align-center {
   margin: 0 auto;
   padding-top: 10px;
-  width: 300px;
+  width: 250px;
 }
 
 .loading-img {
@@ -37,11 +37,11 @@ body {
   width: 100%;
   height: 100%;
   z-index: 100;
-  background: url('../assets/ajax-loader.gif') 50% 50% no-repeat rgb(249, 249, 249);
+  background: url('../assets/ajax-loader.gif') 50% 50% no-repeat;
 }
 .loading-text {
   position: absolute;
-  top: 45%;
+  top: 43%;
   left: 50%;
   transform: translate(-50%, -50%);
   color: #106cc8;
@@ -62,6 +62,7 @@ body {
   background-color: #d0f9b6 !important;
   color: #2a2aff;
 }
+
 .tips {
   font-family: Arial, sans-serif;
   font-size: 12px;
@@ -216,8 +217,201 @@ body {
   padding-top: 0;
 }
 
-@media (min-width: 768px) {
+@media (min-width: 401px) {
   .form-horizontal .control-label {
     padding-top: 0 !important;
+    text-align: right;
+  }
+}
+
+/* Special CSS classes -xxs for small devices such as smart phone (portrait) */
+@media (max-width: 400px) {
+  .col-xxs-1,
+  .col-xxs-10,
+  .col-xxs-11,
+  .col-xxs-12,
+  .col-xxs-2,
+  .col-xxs-3,
+  .col-xxs-4,
+  .col-xxs-5,
+  .col-xxs-6,
+  .col-xxs-7,
+  .col-xxs-8,
+  .col-xxs-9 {
+    float: left;
+    min-height: 1px;
+    padding: 0 5px;
+    position: relative;
+  }
+
+  .col-xxs-12 {
+    width: 100%;
+  }
+  .col-xxs-11 {
+    width: 91.6667%;
+  }
+  .col-xxs-10 {
+    width: 83.3333%;
+  }
+  .col-xxs-9 {
+    width: 75%;
+  }
+  .col-xxs-8 {
+    width: 66.6667%;
+  }
+  .col-xxs-7 {
+    width: 58.3333%;
+  }
+  .col-xxs-6 {
+    width: 50%;
+  }
+  .col-xxs-5 {
+    width: 41.6667%;
+  }
+  .col-xxs-4 {
+    width: 33.3333%;
+  }
+  .col-xxs-3 {
+    width: 25%;
+  }
+  .col-xxs-2 {
+    width: 16.6667%;
+  }
+  .col-xxs-1 {
+    width: 8.33333%;
+  }
+  .col-xxs-pull-12 {
+    right: 100%;
+  }
+  .col-xxs-pull-11 {
+    right: 91.6667%;
+  }
+  .col-xxs-pull-10 {
+    right: 83.3333%;
+  }
+  .col-xxs-pull-9 {
+    right: 75%;
+  }
+  .col-xxs-pull-8 {
+    right: 66.6667%;
+  }
+  .col-xxs-pull-7 {
+    right: 58.3333%;
+  }
+  .col-xxs-pull-6 {
+    right: 50%;
+  }
+  .col-xxs-pull-5 {
+    right: 41.6667%;
+  }
+  .col-xxs-pull-4 {
+    right: 33.3333%;
+  }
+  .col-xxs-pull-3 {
+    right: 25%;
+  }
+  .col-xxs-pull-2 {
+    right: 16.6667%;
+  }
+  .col-xxs-pull-1 {
+    right: 8.33333%;
+  }
+  .col-xxs-pull-0 {
+    right: auto;
+  }
+  .col-xxs-push-12 {
+    left: 100%;
+  }
+  .col-xxs-push-11 {
+    left: 91.6667%;
+  }
+  .col-xxs-push-10 {
+    left: 83.3333%;
+  }
+  .col-xxs-push-9 {
+    left: 75%;
+  }
+  .col-xxs-push-8 {
+    left: 66.6667%;
+  }
+  .col-xxs-push-7 {
+    left: 58.3333%;
+  }
+  .col-xxs-push-6 {
+    left: 50%;
+  }
+  .col-xxs-push-5 {
+    left: 41.6667%;
+  }
+  .col-xxs-push-4 {
+    left: 33.3333%;
+  }
+  .col-xxs-push-3 {
+    left: 25%;
+  }
+  .col-xxs-push-2 {
+    left: 16.6667%;
+  }
+  .col-xxs-push-1 {
+    left: 8.33333%;
+  }
+  .col-xxs-push-0 {
+    left: auto;
+  }
+  .col-xxs-offset-12 {
+    margin-left: 100%;
+  }
+  .col-xxs-offset-11 {
+    margin-left: 91.6667%;
+  }
+  .col-xxs-offset-10 {
+    margin-left: 83.3333%;
+  }
+  .col-xxs-offset-9 {
+    margin-left: 75%;
+  }
+  .col-xxs-offset-8 {
+    margin-left: 66.6667%;
+  }
+  .col-xxs-offset-7 {
+    margin-left: 58.3333%;
+  }
+  .col-xxs-offset-6 {
+    margin-left: 50%;
+  }
+  .col-xxs-offset-5 {
+    margin-left: 41.6667%;
+  }
+  .col-xxs-offset-4 {
+    margin-left: 33.3333%;
+  }
+  .col-xxs-offset-3 {
+    margin-left: 25%;
+  }
+  .col-xxs-offset-2 {
+    margin-left: 16.6667%;
+  }
+  .col-xxs-offset-1 {
+    margin-left: 8.33333%;
+  }
+  .col-xxs-offset-0 {
+    margin-left: 0;
+  }
+
+  .panel-body {
+    padding: 5px;
+  }
+  .form-horizontal .form-group {
+    margin: 0 -5px 5px -5px;
+  }
+
+  .navbar-btn.btn {
+    margin-bottom: 5px;
+    margin-top: 5px;
+  }
+
+  .well {
+    border-radius: 2px;
+    padding: 5px;
   }
 }

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -217,7 +217,17 @@ body {
   padding-top: 0;
 }
 
-@media (min-width: 401px) {
+@media (min-width: 451px) AND (max-width: 550px) {
+  .col-xs-7 {
+    padding-left: 0 !important;
+  }
+
+  .col-xs-5 {
+    padding-left: 0 !important;
+  }
+}
+
+@media (min-width: 451px) {
   .form-horizontal .control-label {
     padding-top: 0 !important;
     text-align: right;
@@ -225,7 +235,7 @@ body {
 }
 
 /* Special CSS classes -xxs for small devices such as smart phone (portrait) */
-@media (max-width: 400px) {
+@media (max-width: 450px) {
   .col-xxs-1,
   .col-xxs-10,
   .col-xxs-11,


### PR DESCRIPTION
The ng2-boostratrap has 4 width ranges for css classes:
xs: <= 767px; sm: 768 ~ 991px;  md: 992 ~ 1199 px; lg: >= 1200px;  

We add an extra smallest range for smart phone portrait width:
xxs: <= 450px; xs: 451 ~ 767px; ... ...

We may change xxs's upper-limit value (450px) based on testing on smart phones.