### PR TITLE
Bundle systemjs in production

### DIFF
--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -26,6 +26,7 @@ export class ProjectConfig extends SeedConfig {
     // Add `NPM` third-party libraries to be injected/bundled.
     this.NPM_DEPENDENCIES = [
       ...this.NPM_DEPENDENCIES,
+      {src: 'systemjs/dist/system.src.js', inject: 'shims'},
       {src: 'moment/moment.js', inject: 'libs'},
       {src: 'ng2-bootstrap/bundles/ng2-bootstrap.js', inject: 'libs'},
       {src: 'ng2-table/bundles/ng2-table.js', inject: 'libs'},


### PR DESCRIPTION
* `ng2-bootstrap` requires `systemjs`
* `npm run serve.prod` now works
* `System.registerDynamic is not a function` is not shown in production
any more
* `shims.js` is successfully loaded and `jsonix` and `ogc-schemas` libraries
are available in production