### PR TITLE
Fix version with `platform-server` version due to `^` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "license": "MIT",
   "devDependencies": {
     "@angular/compiler-cli": "^0.6.1",
-    "@angular/platform-server": "^2.0.0-rc.7",
+    "@angular/platform-server": "2.0.2",
     "@angular/tsc-wrapped": "^0.3.0",
     "async": "^2.0.0",
     "autoprefixer": "^6.3.7",


### PR DESCRIPTION
Trying to fix issues I hit with a clean `npm install` this morning.

It seems [Angular 2.1 has been released 5 days ago](http://angularjs.blogspot.com.au/2016/10/angular-210-now-available.html), package.json should be careful
around which versions of various angular 2 components are being used as
this will be a source on ongoing issue otherwise.

It might help to look at npm shrink wrap or the new `yarn` package
manager to try and reduce these problems as this commit fix only solves
direct dependencies, downstream versions can still get bumped and will
be out of this projects control without npm shink wrap, yarn or
something else to lock down versions.