### PR TITLE
Add default route

### DIFF
--- a/src/client/app/app.routes.ts
+++ b/src/client/app/app.routes.ts
@@ -8,4 +8,9 @@ export const routes: Routes = [
   ...SiteInfoRoutes,
   ...SelectSiteRoutes,
   ...AboutRoutes,
+  {
+    // Default
+    path: '**',
+    redirectTo: '/'
+  }
 ];


### PR DESCRIPTION
* Now only legitimate routes eg. /siteInfo/ADE1, will work
Others will redirect to /.  Note that /siteInfo/ADE1/xcv is
NOT legitimate
* /siteInfo is also incorrect and will redirect to /