### PR TITLE
Fix 'missing MiscUtilsService' error in HumiditySensors

### DIFF
--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -2,6 +2,7 @@ import {Component, Input, Output, EventEmitter} from '@angular/core';
 import {AbstractItem} from '../shared/abstract-groups-items/AbstractItem';
 import {GeodesyEvent} from '../shared/events-messages/Event';
 import {HumiditySensor} from './HumiditySensor';
+import {MiscUtilsService} from '../shared/global/misc-utils.service';
 /**
  * This class represents the SelectSiteComponent for searching and selecting CORS sites.
  */
@@ -44,7 +45,7 @@ export class HumiditySensorItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor() {
+  constructor(private miscUtilsService: MiscUtilsService) {
     super();
   }
 


### PR DESCRIPTION
- seen when in UI attempt to open / close a sensor
- tried to move to AbstractItem but not possible