### PR TITLE
add template for text fields and some example use

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@angular/platform-browser": "2.0.2",
     "@angular/platform-browser-dynamic": "2.0.2",
     "@angular/router": "3.0.0",
-    "alertify.js": "^1.0.10",
+    "angular2-notifications": "0.4.41",
     "bootstrap": "3.3.7",
     "core-js": "^2.4.0",
     "es-module-loader": "^1.0.0",

--- a/src/client/app/pressure-sensor/pressure-sensor.component.html
+++ b/src/client/app/pressure-sensor/pressure-sensor.component.html
@@ -58,41 +58,35 @@
                     <div *ngIf=" pressureSensor == null ">
                         No information available for current GNSS pressure sensor
                     </div>
-                    <div *ngIf=" pressureSensor != null ">
-                        <div class="form-group">
-                            <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label required">Manufacturer</label>
-                            <div class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">
-                                <input required type="text" maxlength="100" class="form-control"
-                                       [(ngModel)]="pressureSensor.manufacturer"
-                                       name="pressureSensorManufacturer_{{i}}"
-                                       #manufacturer="ngModel"/>
-                                 <small [hidden]="manufacturer.valid || manufacturer.pristine"
-                         			class="alert alert-danger">
-                    				"Manufacturer" is required
-                    			 </small>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label required">Serial Number</label>
-                            <div class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">
-                                <input required type="text" maxlength="100" class="form-control"
-                                       [(ngModel)]="pressureSensor.serialNumber"
-                                       name="pressureSensorSerialNumber_{{i}}"
-                                       #serialNumber="ngModel"/>
-                                 <small [hidden]="serialNumber.valid || serialNumber.pristine"
-                         			class="alert alert-danger">
-                    				"Serial Number" is required
-                    			 </small>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Data Sampling Interval (sec)</label>
-                            <div class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">
-                                <input type="number" min="0" maxlength="100" class="form-control"
-                                       [(ngModel)]="pressureSensor.dataSamplingInterval"
-                                       name="pressureSensorDataSamplingInterval_{{i}}"/>
-                            </div>
-                        </div>
+
+                    <div *ngIf=" pressureSensor != null ">            
+
+                        <gnss-text-input
+                            [name]="'pressureSensorManufacturer'"
+                            [label]="'Manufacturer'"
+                            [(model)]="pressureSensor.manufacturer"
+                            [index]="[i]"
+                            [maxlength]="'100'"
+                            [required]="'required'">
+                        </gnss-text-input>
+
+                        <gnss-text-input
+                            [name]="'pressureSensorSerialNumber'"
+                            [label]="'Serial Number'"
+                            [(model)]="pressureSensor.serialNumber"
+                            [index]="[i]"
+                            [maxlength]="'100'"
+                            [required]="'required'">
+                        </gnss-text-input>
+
+                        <gnss-text-input
+                            [name]="'pressureSensorDataSamplingInterval'"
+                            [label]="'Data Sampling Interval (sec)'"
+                            [(model)]="pressureSensor.dataSamplingInterval"
+                            [index]="[i]"
+                            [maxlength]="'100'">
+                        </gnss-text-input>
+
                         <div class="form-group">
                             <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label">Accuracy (hPa)</label>
                             <div class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">

--- a/src/client/app/pressure-sensor/pressure-sensor.module.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { GnssPressureSensorComponent } from './pressure-sensor.component';
+import { DynamicFormFieldsModule } from '../shared/dynamic-form-fields/dynamic-form-fields.module';
 import { DatetimePickerModule } from '../datetime-picker/datetime-picker.module';
+import { GnssPressureSensorComponent } from './pressure-sensor.component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, DatetimePickerModule],
+  imports: [CommonModule, FormsModule, DatetimePickerModule, DynamicFormFieldsModule],
   declarations: [GnssPressureSensorComponent],
-  exports: [GnssPressureSensorComponent],
+  exports: [GnssPressureSensorComponent, DynamicFormFieldsModule],
 })
 export class PressureSensorModule { }

--- a/src/client/app/select-site/select-site.component.html
+++ b/src/client/app/select-site/select-site.component.html
@@ -1,3 +1,4 @@
+<simple-notifications [options]="notificationsOtions"></simple-notifications>
 <div class="container centered clear-pad">
   <div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12 pad-sm">
     <div class="panel-group">

--- a/src/client/app/select-site/select-site.component.ts
+++ b/src/client/app/select-site/select-site.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs/Subscription';
 import { Subject } from 'rxjs/Subject';
 import 'rxjs/add/operator/debounceTime';
 import { DialogService, MiscUtilsService, CorsSiteService, ServiceWorkerService } from '../shared/index';
+import { NotificationsService } from 'angular2-notifications';
 
 /**
  * This class represents the SelectSiteComponent for searching and selecting CORS sites.
@@ -30,6 +31,21 @@ export class SelectSiteComponent implements OnInit {
   ];
 
 
+  public notificationsOtions: any = {
+    timeOut: 5000,
+    lastOnBottom: true,
+    clickToClose: true,
+    maxLength: 0,
+    maxStack: 7,
+    showProgressBar: true,
+    pauseOnHover: true,
+    preventDuplicates: false,
+    preventLastDuplicates: 'visible',
+    rtl: false,
+    animate: 'scale',
+    position: ['right', 'bottom']
+  };
+
   /**
    * Creates an instance of the SelectSiteComponent with the injected CorsSiteService.
    *
@@ -43,7 +59,9 @@ export class SelectSiteComponent implements OnInit {
               public corsSiteService: CorsSiteService,
               private dialogService: DialogService,
               private miscUtilsService: MiscUtilsService,
-              private serviceWorkerService: ServiceWorkerService) { }
+              private serviceWorkerService: ServiceWorkerService,
+              private notificationsService: NotificationsService
+  ) { }
 
   /**
    * Initialize relevant variables when the directive is instantiated
@@ -90,6 +108,8 @@ export class SelectSiteComponent implements OnInit {
     this.errorMessage = null;
     this.isSearching = true;
     this.sites = [];
+    this.notificationsService.alert('alert', 'content');
+
     this.corsSiteService.getCorsSitesByUsingWFS(fourCharacterId, siteName)
       .subscribe(
         (responseJson: any) => this.sites = responseJson,

--- a/src/client/app/select-site/select-site.module.ts
+++ b/src/client/app/select-site/select-site.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SelectSiteComponent } from './select-site.component';
+import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
-  imports: [CommonModule],
+  imports: [CommonModule, SharedModule],
   declarations: [SelectSiteComponent],
   exports: [SelectSiteComponent],
 })

--- a/src/client/app/shared/dynamic-form-fields/dynamic-form-fields.module.ts
+++ b/src/client/app/shared/dynamic-form-fields/dynamic-form-fields.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { TextInputComponent } from './text-input.component';
+
+@NgModule({
+  imports: [CommonModule, FormsModule],
+  declarations: [TextInputComponent],
+  exports: [TextInputComponent]
+})
+export class DynamicFormFieldsModule { }

--- a/src/client/app/shared/dynamic-form-fields/index.ts
+++ b/src/client/app/shared/dynamic-form-fields/index.ts
@@ -1,0 +1,5 @@
+/**
+ * This barrel file provides the export for the lazy loaded Text Field component.
+ */
+export * from './dynamic-form-fields.module';
+export * from './text-input.component';

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.css
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.css
@@ -1,0 +1,5 @@
+.form-group.required .control-label::after,
+.form-group .control-label.required::after {
+  color: green;
+  content: "*";
+}

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.html
@@ -1,0 +1,26 @@
+<div class="form-group">
+    
+    <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label {{required}}">{{label}}</label>
+    
+    <div class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">
+         
+         <input 
+             type="text" 
+             class="form-control"
+             required={{required}} 
+             minlength="{{minlength}}" 
+             maxlength="{{maxlength}}"
+             [ngModel]="model" 
+             (ngModelChange)="change($event)"
+             name="{{name}}_{{index}}"
+             #name="ngModel"/>                  
+                
+         <small 
+             *ngIf="required == 'required'"
+             [hidden]="name.valid || name.pristine"
+             class="alert alert-danger"> 
+             "{{label}}" is required <span *ngIf="minlength != ''"> (minimum {{minlength}} characters)</span>
+         </small>
+                     
+    </div>
+</div>

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.ts
@@ -1,0 +1,25 @@
+import {Component, Input, Output, EventEmitter} from '@angular/core';
+
+@Component({
+  moduleId: module.id,
+  selector: 'gnss-text-input',
+  templateUrl: 'text-input.component.html',
+  styleUrls: ['text-input.component.css']
+})
+export class TextInputComponent {
+  @Input() name: string = '';
+  @Input() label: string = '';
+  @Input() model: string = '';
+  @Input() index: string = '0';
+  @Input() required: string = '';
+  @Input() minlength: string = '';
+  @Input() maxlength: string = '';
+
+  /* Output an event when the value in the field changes */
+  @Output() modelChange = new EventEmitter();
+  change(newValue:string) {
+    console.log('newvalue', newValue);
+    this.model = newValue;
+    this.modelChange.emit(newValue);
+  }
+}

--- a/src/client/app/shared/global/dialog.service.ts
+++ b/src/client/app/shared/global/dialog.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class DialogService {
-  private _alertify: any = require('alertify.js');
+  // private _aler?tify: any = require('alertify.js');
 
   /*
    * Opens a customised dialog showing the changes made and prompts the user to confirm before saving
@@ -19,59 +19,65 @@ export class DialogService {
    * Opens a confirmation dialog and acts accordingly in response to users' choice
    */
   public showConfirmDialog(message: string, okCallback: () => any, cancelCallback: () => any) {
-    this._alertify.okBtn('Yes').cancelBtn('Cancel')
-      .confirm(message, function (event: any) {
-        event.preventDefault();
-        okCallback();
-      }, function(event: any) {
-        event.preventDefault();
-        cancelCallback();
-      }
-    );
+    // this._alertify.okBtn('Yes').cancelBtn('Cancel')
+    //   .confirm(message, function (event: any) {
+    //     event.preventDefault();
+    //     okCallback();
+    //   }, function(event: any) {
+    //     event.preventDefault();
+    //     cancelCallback();
+    //   }
+    // );
+    console.log(message);
   }
 
   /*
    * Opens a dialog prompting user to input a value for it
    */
   public showPromptDialog(message: string, okCallback: () => any) {
-    let that: any = this;
-    this._alertify.defaultValue('Default Value').prompt(message,
-      function (value: any, event: any) {
-        event.preventDefault();
-        that.showSuccessMessage('You clicked OK and typed: ' + value);
-      }, function(event: any) {
-        event.preventDefault();
-        that.showLogMessage('You clicked Cancel');
-      }
-    );
+    // let that: any = this;
+    // this._alertify.defaultValue('Default Value').prompt(message,
+    //   function (value: any, event: any) {
+    //     event.preventDefault();
+    //     that.showSuccessMessage('You clicked OK and typed: ' + value);
+    //   }, function(event: any) {
+    //     event.preventDefault();
+    //     that.showLogMessage('You clicked Cancel');
+    //   }
+    // );
+    console.log(message);
   }
 
   /*
    * Displays a dialog with alert message
    */
   public showAlertDialog(message: string) {
-    this._alertify.alert(message);
+    // this._alertify.alert(message);
+    console.log(message);
   }
 
   /*
    * Displays a success/yes message in green color for 10 seconds at the bottom-left corner
    */
   public showSuccessMessage(message: string) {
-    this._alertify.maxLogItems(1).closeLogOnClick(true).success(message);
+    // this._alertify.maxLogItems(1).closeLogOnClick(true).success(message);
+    console.log(message);
   }
 
   /*
    * Displays an error/no message in red color for 10 seconds at the bottom-left corner
    */
   public showErrorMessage(message: string) {
-    this._alertify.maxLogItems(1).closeLogOnClick(true).error(message);
+    // this._alertify.maxLogItems(1).closeLogOnClick(true).error(message);
+    console.log(message);
   }
 
   /*
    * Displays an log message in black color for 10 seconds at the bottom-left corner
    */
   public showLogMessage(message: string) {
-    this._alertify.maxLogItems(1).closeLogOnClick(true).log(message);
+    // this._alertify.maxLogItems(1).closeLogOnClick(true).log(message);
+    console.log(message);
   }
 
 }

--- a/src/client/app/shared/shared.module.ts
+++ b/src/client/app/shared/shared.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { DropdownModule, TooltipModule,  } from 'ng2-bootstrap';
+import { SimpleNotificationsModule } from 'angular2-notifications';
 
 import { ToolbarComponent } from './toolbar/index';
 import { NavbarComponent } from './navbar/index';
@@ -19,10 +20,10 @@ import { ConstantsService, HttpUtilsService } from './global/index';
  */
 
 @NgModule({
-  imports: [CommonModule, RouterModule, DropdownModule, TooltipModule],
+  imports: [CommonModule, RouterModule, DropdownModule, TooltipModule, SimpleNotificationsModule],
   declarations: [ToolbarComponent, NavbarComponent],
   exports: [ToolbarComponent, NavbarComponent,
-    CommonModule, FormsModule, RouterModule],
+    CommonModule, FormsModule, RouterModule, SimpleNotificationsModule],
 })
 export class SharedModule {
   static forRoot(): ModuleWithProviders {

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -86,7 +86,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     private miscUtilsService: MiscUtilsService,
     private siteLogService: SiteLogService,
     private jsonDiffService: JsonDiffService,
-    private jsonCheckService: JsonCheckService
+    private jsonCheckService: JsonCheckService,
   ) {}
 
   /**

--- a/src/client/app/site-info/site-info.module.ts
+++ b/src/client/app/site-info/site-info.module.ts
@@ -26,8 +26,7 @@ import { WaterVaporSensorModule } from '../water-vapor-sensor/water-vapor-sensor
     TemperatureSensorModule,
     WaterVaporSensorModule,
     EpisodicEffectModule,
-    FrequencyStandardModule
-  ],
+    FrequencyStandardModule],
   declarations: [SiteInfoComponent],
   exports: [SiteInfoComponent],
 })

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -43,9 +43,9 @@ export class ProjectConfig extends SeedConfig {
       {src: 'ogc-schemas/lib/Filter_2_0.js', inject: 'libs'},
       {src: 'ogc-schemas/lib/OWS_1_1_0.js', inject: 'libs'},
       {src: 'ogc-schemas/lib/WFS_2_0.js', inject: 'libs'},
-      {src: 'alertify.js/dist/js/ngAlertify.js', inject: 'libs'},
       {src: 'lodash/lodash.js', inject: 'libs'},
       {src: 'foreach/index.js', inject: 'libs'},
+      {src: 'angular2-notifications/components.js', inject: 'libs'},
     ];
 
     this.SYSTEM_CONFIG_DEV.paths['ng2-bootstrap'] =
@@ -53,14 +53,6 @@ export class ProjectConfig extends SeedConfig {
 
     this.SYSTEM_BUILDER_CONFIG.packages['ng2-bootstrap'] = {
       main: 'ng2-bootstrap',
-      defaultExtension : 'js'
-    };
-
-    this.SYSTEM_CONFIG_DEV.paths['alertify'] =
-      `${this.APP_BASE}node_modules/alertify.js/dist/js/ngAlertify`;
-
-    this.SYSTEM_BUILDER_CONFIG.packages['alertify'] = {
-      main: 'ngAlertify',
       defaultExtension : 'js'
     };
 
@@ -77,6 +69,14 @@ export class ProjectConfig extends SeedConfig {
 
     this.SYSTEM_BUILDER_CONFIG.packages['foreach'] = {
       main: 'index',
+      defaultExtension : 'js'
+    };
+
+    this.SYSTEM_CONFIG_DEV.paths['angular2-notifications'] =
+      `${this.APP_BASE}node_modules/angular2-notifications`;
+
+    this.SYSTEM_BUILDER_CONFIG.packages['angular2-notifications'] = {
+      main: 'components',
       defaultExtension : 'js'
     };
 


### PR DESCRIPTION
Three example fields added in pressure sensors
Manufacturer (required)
Serial Number (required)
Data Sampling Interval (not required)

there is functionality available that is not demonstrated in this PR: minimum length
for example: 
        <gnss-text-input 
              [model]="site.fourCharacterID"
              [name]="fourCharacterID"
              [label]="'Four Character Id'"
              [required]="'required'"
              [minlength]="'4'"
              [maxlength]="'9'">
         </gnss-text-input>

I think we would also want to pass in the units of measurement so that we can construct better validation messages (ie we don't necessarily want to use the label in those messages although it might be fine, I don't know)

This does not support type="number" fields

It uses template-driven forms and doesn't save THAT much lines of html code. But it is way neater and easier to scan.
