### PR TITLE
remove default dates from humidity sensor constructor

### DIFF
--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -5,7 +5,7 @@ import {HumiditySensorViewModel} from './humidity-sensor-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 
 /**
- * This class represents the SelectSiteComponent for searching and selecting CORS sites.
+ * This class represents a single Humidity Sensor.
  */
 @Component({
   moduleId: module.id,

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
@@ -1,5 +1,4 @@
 import {HumiditySensorViewModel} from './humidity-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
 export function main() {
   let humiditySensorsViewModel: HumiditySensorViewModel;
 
@@ -19,13 +18,10 @@ export function main() {
       expect(humiditySensorsViewModel.manufacturer).toEqual('');
       expect(humiditySensorsViewModel.notes).toEqual('');
       expect(humiditySensorsViewModel.serialNumber).toEqual('');
-      // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
       expect(humiditySensorsViewModel.calibrationDate).toBeDefined();
-      expect(humiditySensorsViewModel.calibrationDate).not.toEqual('');
-      expect(humiditySensorsViewModel.calibrationDate).toContain(nowPart);
+      expect(humiditySensorsViewModel.calibrationDate).toEqual('');
       expect(humiditySensorsViewModel.startDate).toBeDefined();
-      expect(humiditySensorsViewModel.startDate).toContain(nowPart);
+      expect(humiditySensorsViewModel.startDate).toEqual('');
       expect(humiditySensorsViewModel.endDate).toEqual('');
     });
   });

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
@@ -20,10 +20,9 @@ export class HumiditySensorViewModel extends AbstractViewModel {
 
   constructor() {
     super();
-    let presentDT: string = MiscUtils.getPresentDateTime();
 
-    this.startDate = presentDT;
-    this.calibrationDate = presentDT;
+    this.startDate = '';
+    this.calibrationDate = '';
     this.endDate = '';
     this.dataSamplingInterval =  0;
     this.accuracyPercentRelativeHumidity = 0;

--- a/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
@@ -4,7 +4,7 @@ import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
 import {HumiditySensorViewModel} from './humidity-sensor-view-model';
 
 /**
- * This class represents the SelectSiteComponent for searching and selecting CORS sites.
+ * This class represents a group of Humidity Sensors.
  */
 @Component({
   moduleId: module.id,
@@ -44,8 +44,10 @@ export class HumiditySensorsGroupComponent extends AbstractGroup<HumiditySensorV
     }
   }
 
-   /* **************************************************
-   * Other methods
+  /**
+   * Create a new view model and set any required default values .
+   * These are set here so that only selecting "new item" in the UI
+   * sets default values and loading an invalid record from the database does not.
    */
   newViewModelItem(): HumiditySensorViewModel {
     let viewModel = new HumiditySensorViewModel();

--- a/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
@@ -48,6 +48,10 @@ export class HumiditySensorsGroupComponent extends AbstractGroup<HumiditySensorV
    * Other methods
    */
   newViewModelItem(): HumiditySensorViewModel {
-    return new HumiditySensorViewModel();
+    let viewModel = new HumiditySensorViewModel();
+    let presentDT: string = MiscUtils.getPresentDateTime();
+    viewModel.startDate = presentDT;
+    viewModel.calibrationDate = presentDT;
+    return viewModel;
   }
 }

--- a/src/client/app/humidity-sensor/index.ts
+++ b/src/client/app/humidity-sensor/index.ts
@@ -1,5 +1,2 @@
-/**
- * This barrel file provides the export for the lazy loaded SelectSiteComponent.
- */
 export * from './humidity-sensor-item.component';
 export * from './humidity-sensors-group.component';

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
@@ -1,5 +1,4 @@
 import {PressureSensorViewModel} from './pressure-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
 export function main() {
   let pressureSensorsViewModel: PressureSensorViewModel;
 
@@ -18,13 +17,10 @@ export function main() {
       expect(pressureSensorsViewModel.manufacturer).toEqual('');
       expect(pressureSensorsViewModel.notes).toEqual('');
       expect(pressureSensorsViewModel.serialNumber).toEqual('');
-      // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
       expect(pressureSensorsViewModel.calibrationDate).toBeDefined();
-      expect(pressureSensorsViewModel.calibrationDate).not.toEqual('');
-      expect(pressureSensorsViewModel.calibrationDate).toContain(nowPart);
+      expect(pressureSensorsViewModel.calibrationDate).toEqual('');
       expect(pressureSensorsViewModel.startDate).toBeDefined();
-      expect(pressureSensorsViewModel.startDate).toContain(nowPart);
+      expect(pressureSensorsViewModel.startDate).toEqual('');
       expect(pressureSensorsViewModel.endDate).toEqual('');
     });
   });

--- a/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
@@ -45,6 +45,10 @@ export class PressureSensorsGroupComponent extends AbstractGroup<PressureSensorV
   }
 
   newViewModelItem(): PressureSensorViewModel {
-    return new PressureSensorViewModel();
+    let viewModel = new PressureSensorViewModel();
+    let presentDT: string = MiscUtils.getPresentDateTime();
+    viewModel.startDate = presentDT;
+    viewModel.calibrationDate = presentDT;
+    return viewModel;
   }
 }

--- a/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
@@ -44,6 +44,11 @@ export class PressureSensorsGroupComponent extends AbstractGroup<PressureSensorV
     }
   }
 
+  /**
+   * Create a new view model and set any required default values .
+   * These are set here so that only selecting "new item" in the UI
+   * sets default values and loading an invalid record from the database does not.
+   */
   newViewModelItem(): PressureSensorViewModel {
     let viewModel = new PressureSensorViewModel();
     let presentDT: string = MiscUtils.getPresentDateTime();


### PR DESCRIPTION
and add to the newViewModelItem function
in humidity and pressure sensors
so that we get default dates in a new item but not when we load records
 with missing data from the database