### PR TITLE
fix validation for required and invalid date strings

### DIFF
--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
@@ -21,8 +21,7 @@
         </span>
       </div>
       <small [hidden]="!invalidDatetime" class="alert alert-danger">
-        "{{label}}" is {{ (isRequired() && datetime.length == 0) ? "required" : "not valid" }}.
-        (Valid Date Format: YYYY-MM-DD hh:mm:ss)
+        {{getValidationMessage()}}
       </small>
 
       <div class="calendar-popup" *ngIf="showDatetimePicker">

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -353,4 +353,20 @@ export class DatetimeInputComponent implements OnInit, DoCheck {
   public isRequired() : boolean {
     return this.required || (this.requiredIfNotCurrent && this.index[0] !== 0);
   }
+
+  /**
+   * Get a validation message to apply if the input string is:
+   *   1. required but not supplied, or
+   *   2. supplied but not a valid date
+   */
+  public getValidationMessage() {
+    let message = this.label + ' is ';
+    if (this.isRequired() && !this.datetimeDisplay) {
+      message += ' required ';
+    } else if (this.invalidDatetime) {
+      message += ' not valid ';
+    }
+    message += '(Valid Date Format: YYYY-MM-DD hh:mm:ss)';
+    return message;
+  }
 }


### PR DESCRIPTION
I moved the logic into the component to debug it mainly but actually i think it is much nicer having it there rather than in the template.
Tested in the UI and it works very well now in Firefox and Chrome.
I haven't retrofitted this code into the old datetime component and I'm not interested in doing that, I'd prefer to replace them all with the new component. 