### PR TITLE
Updated to the latest version of typescript (2.1.5).

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "ts-node": "^1.0.0",
     "tslint": "^3.13.0",
     "tslint-stylish": "2.1.0-beta",
-    "typescript": "^2.0.2",
+    "typescript": "^2.1.5",
     "typings": "^1.3.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
Required when the latest version of @types/lodash (4.14.52) caused compile errors.