### PR TITLE
GEOD-366 - After new and save 'cancel' change to 'delete'

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {FrequencyStandardViewModel} from './frequency-standard-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This class represents a single item of GNSS Antennas.
@@ -43,8 +44,8 @@ export class FrequencyStandardItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService) {
-    super(dialogService);
+  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+      super(dialogService, siteLogService);
   }
 
   getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -1,66 +1,66 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {FrequencyStandardViewModel} from './frequency-standard-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { FrequencyStandardViewModel } from './frequency-standard-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This class represents a single item of GNSS Antennas.
  */
 @Component({
-  moduleId: module.id,
-  selector: 'frequency-standard-item',
-  templateUrl: 'frequency-standard-item.component.html',
+    moduleId: module.id,
+    selector: 'frequency-standard-item',
+    templateUrl: 'frequency-standard-item.component.html',
 })
 export class FrequencyStandardItemComponent extends AbstractItem {
-  public miscUtils: any = MiscUtils;
+    public miscUtils: any = MiscUtils;
 
-  /**
-   * Total number of Frequency Standards
-   */
-  @Input() total: number;
+    /**
+     * Total number of Frequency Standards
+     */
+    @Input() total: number;
 
-  /**
-   * The index of this Frequency Standard (zero-based)
-   */
-  @Input() index: number;
+    /**
+     * The index of this Frequency Standard (zero-based)
+     */
+    @Input() index: number;
 
-  /**
-   * The Frequency Standard in question.
-   */
-  @Input() frequencyStandard: FrequencyStandardViewModel;
+    /**
+     * The Frequency Standard in question.
+     */
+    @Input() frequencyStandard: FrequencyStandardViewModel;
 
-  /**
-   * This is to receive geodesyEvent from parent.
-   */
-  @Input() geodesyEvent: GeodesyEvent;
+    /**
+     * This is to receive geodesyEvent from parent.
+     */
+    @Input() geodesyEvent: GeodesyEvent;
 
-  /**
-   * Events children components can send to their parent components. Usually these are then passed to all
-   * child components.
-   * @type {EventEmitter<boolean>}
-   */
-  @Output() returnEvents = new EventEmitter<GeodesyEvent>();
+    /**
+     * Events children components can send to their parent components. Usually these are then passed to all
+     * child components.
+     * @type {EventEmitter<boolean>}
+     */
+    @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      super(dialogService, siteLogService);
-  }
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
+    }
 
-  getGeodesyEvent(): GeodesyEvent {
-    return this.geodesyEvent;
-  }
+    getGeodesyEvent(): GeodesyEvent {
+        return this.geodesyEvent;
+    }
 
-  getIndex(): number {
-    return this.index;
-  }
+    getIndex(): number {
+        return this.index;
+    }
 
-  getReturnEvents(): EventEmitter<GeodesyEvent> {
-    return this.returnEvents;
-  }
+    getReturnEvents(): EventEmitter<GeodesyEvent> {
+        return this.returnEvents;
+    }
 
-  getItemName(): string {
-    return 'Frequency Standard';
-  }
+    getItemName(): string {
+        return 'Frequency Standard';
+    }
 }

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {GnssAntennaViewModel} from './gnss-antenna-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This class represents a single item of GNSS Antennas.
@@ -43,8 +44,8 @@ export class GnssAntennaItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService) {
-    super(dialogService);
+  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+      super(dialogService, siteLogService);
   }
 
   getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -1,66 +1,66 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {GnssAntennaViewModel} from './gnss-antenna-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { GnssAntennaViewModel } from './gnss-antenna-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This class represents a single item of GNSS Antennas.
  */
 @Component({
-  moduleId: module.id,
-  selector: 'gnss-antenna-item',
-  templateUrl: 'gnss-antenna-item.component.html',
+    moduleId: module.id,
+    selector: 'gnss-antenna-item',
+    templateUrl: 'gnss-antenna-item.component.html',
 })
 export class GnssAntennaItemComponent extends AbstractItem {
-  public miscUtils: any = MiscUtils;
+    public miscUtils: any = MiscUtils;
 
-  /**
-   * Total number of GNSS antennas
-   */
-  @Input() total: number;
+    /**
+     * Total number of GNSS antennas
+     */
+    @Input() total: number;
 
-  /**
-   * The index of this antenna (zero-based)
-   */
-  @Input() index: number;
+    /**
+     * The index of this antenna (zero-based)
+     */
+    @Input() index: number;
 
-  /**
-   * The GNSS Antenna in question.
-   */
-  @Input() antenna: GnssAntennaViewModel;
+    /**
+     * The GNSS Antenna in question.
+     */
+    @Input() antenna: GnssAntennaViewModel;
 
-  /**
-   * This is to receive geodesyEvent from parent.
-   */
-  @Input() geodesyEvent: GeodesyEvent;
+    /**
+     * This is to receive geodesyEvent from parent.
+     */
+    @Input() geodesyEvent: GeodesyEvent;
 
-  /**
-   * Events children components can send to their parent components.  Usually these are then passed to all
-   * child components.
-   * @type {EventEmitter<boolean>}
-   */
-  @Output() returnEvents = new EventEmitter<GeodesyEvent>();
+    /**
+     * Events children components can send to their parent components.  Usually these are then passed to all
+     * child components.
+     * @type {EventEmitter<boolean>}
+     */
+    @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      super(dialogService, siteLogService);
-  }
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
+    }
 
-  getGeodesyEvent(): GeodesyEvent {
-    return this.geodesyEvent;
-  }
+    getGeodesyEvent(): GeodesyEvent {
+        return this.geodesyEvent;
+    }
 
-  getIndex(): number {
-    return this.index;
-  }
+    getIndex(): number {
+        return this.index;
+    }
 
-  getReturnEvents(): EventEmitter<GeodesyEvent> {
-    return this.returnEvents;
-  }
+    getReturnEvents(): EventEmitter<GeodesyEvent> {
+        return this.returnEvents;
+    }
 
-  getItemName(): string {
-    return 'GNSS Antenna';
-  }
+    getItemName(): string {
+        return 'GNSS Antenna';
+    }
 }

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {GnssReceiverViewModel} from './gnss-receiver-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single GNSS Receiver.
@@ -41,8 +42,8 @@ export class GnssReceiverItemComponent extends AbstractItem {
      */
     @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-    constructor(protected dialogService: DialogService) {
-        super(dialogService);
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
     }
 
     getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -1,10 +1,10 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {GnssReceiverViewModel} from './gnss-receiver-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { GnssReceiverViewModel } from './gnss-receiver-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single GNSS Receiver.

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {HumiditySensorViewModel} from './humidity-sensor-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Humidity Sensor.
@@ -41,8 +42,8 @@ export class HumiditySensorItemComponent extends AbstractItem {
      */
     @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-    constructor(protected dialogService: DialogService) {
-        super(dialogService);
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
     }
 
     getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -1,10 +1,10 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {HumiditySensorViewModel} from './humidity-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { HumiditySensorViewModel } from './humidity-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Humidity Sensor.

--- a/src/client/app/local-episodic-event/local-episodic-event-item.component.ts
+++ b/src/client/app/local-episodic-event/local-episodic-event-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {LocalEpisodicEventViewModel} from './local-episodic-event-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Local Episodic Effect.
@@ -41,8 +42,8 @@ export class LocalEpisodicEventItemComponent extends AbstractItem {
      */
     @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-    constructor(protected dialogService: DialogService) {
-        super(dialogService);
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
     }
 
     getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {PressureSensorViewModel} from './pressure-sensor-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Pressure Sensor.
@@ -41,8 +42,8 @@ export class PressureSensorItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService) {
-    super(dialogService);
+  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+      super(dialogService, siteLogService);
   }
 
   getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -1,64 +1,64 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {PressureSensorViewModel} from './pressure-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { PressureSensorViewModel } from './pressure-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Pressure Sensor.
  */
 @Component({
-  moduleId: module.id,
-  selector: 'pressure-sensor-item',
-  templateUrl: 'pressure-sensor-item.component.html',
+    moduleId: module.id,
+    selector: 'pressure-sensor-item',
+    templateUrl: 'pressure-sensor-item.component.html',
 })
 export class PressureSensorItemComponent extends AbstractItem {
-  public miscUtils: any = MiscUtils;
+    public miscUtils: any = MiscUtils;
 
-  /**
-   * Total number of pressureSensors
-   */
-  @Input() total: number;
-  /**
-   * The index of this sensor (zero-based)
-   */
-  @Input() index: number;
-  /**
-   * The PressureSensor in question.
-   */
-  @Input() pressureSensor: PressureSensorViewModel;
+    /**
+     * Total number of pressureSensors
+     */
+    @Input() total: number;
+    /**
+     * The index of this sensor (zero-based)
+     */
+    @Input() index: number;
+    /**
+     * The PressureSensor in question.
+     */
+    @Input() pressureSensor: PressureSensorViewModel;
 
-  /**
-   * This is to receive geodesyEvent from parent.
-   */
-  @Input() geodesyEvent: GeodesyEvent;
+    /**
+     * This is to receive geodesyEvent from parent.
+     */
+    @Input() geodesyEvent: GeodesyEvent;
 
-  /**
-   * Events children components can send to their parent components.  Usually these are then passed to all
-   * child components.
-   * @type {EventEmitter<boolean>}
-   */
-  @Output() returnEvents = new EventEmitter<GeodesyEvent>();
+    /**
+     * Events children components can send to their parent components.  Usually these are then passed to all
+     * child components.
+     * @type {EventEmitter<boolean>}
+     */
+    @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      super(dialogService, siteLogService);
-  }
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
+    }
 
-  getGeodesyEvent(): GeodesyEvent {
-    return this.geodesyEvent;
-  }
+    getGeodesyEvent(): GeodesyEvent {
+        return this.geodesyEvent;
+    }
 
-  getIndex(): number {
-    return this.index;
-  }
+    getIndex(): number {
+        return this.index;
+    }
 
-  getReturnEvents(): EventEmitter<GeodesyEvent> {
-    return this.returnEvents;
-  }
+    getReturnEvents(): EventEmitter<GeodesyEvent> {
+        return this.returnEvents;
+    }
 
-  getItemName(): string {
-    return 'Pressure Sensor';
-  }
+    getItemName(): string {
+        return 'Pressure Sensor';
+    }
 }

--- a/src/client/app/shared/abstract-groups-items/abstract-item.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.ts
@@ -5,7 +5,7 @@ import {SiteLogService} from '../site-log/site-log.service';
 import {Subscription} from 'rxjs';
 
 export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
-    private subscription: Subscription;
+    private isSavedSubscription: Subscription;
 
     protected isNew: boolean = false;
 
@@ -49,7 +49,7 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
     }
 
     private setupSubscriptions() {
-        this.subscription = this.siteLogService.getSavedSubscription().subscribe(saved => {
+        this.isSavedSubscription = this.siteLogService.getIsSavedSubscription().subscribe(() => {
             console.log('Abstract item for '+ this.getItemName() + ' - isNew: '+ this.isNew +', changed to false');
             this.isNew = false;
         });
@@ -61,7 +61,7 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
 
     ngOnDestroy() {
         // unsubscribe to ensure no memory leaks
-        this.subscription.unsubscribe();
+        this.isSavedSubscription.unsubscribe();
     }
     /**
      * Angular doesn't detect changes in objects and need to perform the check with this lifecycle hook ourselves.

--- a/src/client/app/shared/abstract-groups-items/abstract-item.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.ts
@@ -1,8 +1,8 @@
 import { GeodesyEvent, EventNames } from '../events-messages/Event';
-import {EventEmitter, DoCheck, OnInit, OnDestroy} from '@angular/core';
+import { EventEmitter, DoCheck, OnInit, OnDestroy } from '@angular/core';
 import { DialogService } from '../index';
-import {SiteLogService} from '../site-log/site-log.service';
-import {Subscription} from 'rxjs';
+import { SiteLogService } from '../site-log/site-log.service';
+import { Subscription } from 'rxjs';
 
 export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
     private isSavedSubscription: Subscription;
@@ -39,18 +39,18 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
      */
     abstract getItemName(): string;
 
-  /**
-   * Creates an instance of the AbstractItem with the injected Services.
-   *
-   * @param {DialogService} dialogService - The injected DialogService.
-   */
+    /**
+     * Creates an instance of the AbstractItem with the injected Services.
+     *
+     * @param {DialogService} dialogService - The injected DialogService.
+     */
     constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      this.setupSubscriptions();
+        this.setupSubscriptions();
     }
 
     private setupSubscriptions() {
         this.isSavedSubscription = this.siteLogService.getIsSavedSubscription().subscribe(() => {
-            console.log('Abstract item for '+ this.getItemName() + ' - isNew: '+ this.isNew +', changed to false');
+            console.log('Abstract item for ' + this.getItemName() + ' - isNew: ' + this.isNew + ', changed to false');
             this.isNew = false;
         });
     }
@@ -63,6 +63,7 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
         // unsubscribe to ensure no memory leaks
         this.isSavedSubscription.unsubscribe();
     }
+
     /**
      * Angular doesn't detect changes in objects and need to perform the check with this lifecycle hook ourselves.
      *
@@ -114,29 +115,29 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
      */
     removeItem(index: number) {
 
-      let deleteReason: string = 'New item not needed';
+        let deleteReason: string = 'New item not needed';
 
-      if (this.isNew) {
-        this.cancelNew(index, deleteReason);
-      } else {
-          this.dialogService.confirmDeleteDialog(
-            this.getItemName(),
-            (deleteReason : string) => {
-               // ok callback
-               this.deleteItem(index, deleteReason);
-            },
-            () => {
-              // cancel callback
-              console.log('delete cancelled by user');
-            }
-          );
-      }
+        if (this.isNew) {
+            this.cancelNew(index, deleteReason);
+        } else {
+            this.dialogService.confirmDeleteDialog(
+                this.getItemName(),
+                (deleteReason: string) => {
+                    // ok callback
+                    this.deleteItem(index, deleteReason);
+                },
+                () => {
+                    // cancel callback
+                    console.log('delete cancelled by user');
+                }
+            );
+        }
     }
 
     /**
      *  Mark an item for deletion using the specified reason.
      */
-    private deleteItem(index: number, deleteReason : string) {
+    private deleteItem(index: number, deleteReason: string) {
         console.log('child call removeItem(' + index + ')');
         let geodesyEvent: GeodesyEvent = {name: EventNames.removeItem, valueNumber: index, valueString: deleteReason};
         this.getReturnEvents().emit(geodesyEvent);
@@ -145,7 +146,7 @@ export abstract class AbstractItem implements DoCheck, OnInit, OnDestroy {
     /**
      *  Mark an item for deletion using the specified reason.
      */
-    private cancelNew(index: number, deleteReason : string) {
+    private cancelNew(index: number, deleteReason: string) {
         console.log('child call cancelNew(' + index + ')');
         let geodesyEvent: GeodesyEvent = {name: EventNames.cancelNew, valueNumber: index, valueString: deleteReason};
         this.getReturnEvents().emit(geodesyEvent);

--- a/src/client/app/shared/site-log/site-log.service.ts
+++ b/src/client/app/shared/site-log/site-log.service.ts
@@ -1,15 +1,15 @@
-import {Injectable} from '@angular/core';
-import {Http, Response} from '@angular/http';
-import {Observable, Subject} from 'rxjs/Rx';
+import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+import { Observable, Subject } from 'rxjs/Rx';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import {JsonixService} from '../jsonix/jsonix.service';
-import {WFSService, SelectSiteSearchType} from '../wfs/wfs.service';
-import {HttpUtilsService} from '../global/http-utils.service';
-import {ConstantsService} from '../global/constants.service';
-import {JsonViewModelService} from '../json-data-view-model/json-view-model.service';
-import {SiteLogViewModel} from '../json-data-view-model/view-model/site-log-view-model';
-import {SiteLogDataModel} from '../json-data-view-model/data-model/site-log-data-model';
+import { JsonixService } from '../jsonix/jsonix.service';
+import { WFSService, SelectSiteSearchType } from '../wfs/wfs.service';
+import { HttpUtilsService } from '../global/http-utils.service';
+import { ConstantsService } from '../global/constants.service';
+import { JsonViewModelService } from '../json-data-view-model/json-view-model.service';
+import { SiteLogViewModel } from '../json-data-view-model/view-model/site-log-view-model';
+import { SiteLogDataModel } from '../json-data-view-model/data-model/site-log-data-model';
 
 /**
  * This class provides the service with methods to retrieve CORS Setup info from DB.
@@ -183,8 +183,8 @@ export class SiteLogService {
         console.log('saveSiteLog - siteLogDataModel: ', siteLogDataModel);
 
         // wrap the JSON object in a "geo:siteLog" element before converting to GeodesyML
-        let siteLogJsonObj : any = {
-            'geo:siteLog' : siteLogDataModel
+        let siteLogJsonObj: any = {
+            'geo:siteLog': siteLogDataModel
         };
 
         let siteLogML: string = this.jsonixService.jsonToGeodesyML(siteLogJsonObj);

--- a/src/client/app/shared/site-log/site-log.service.ts
+++ b/src/client/app/shared/site-log/site-log.service.ts
@@ -16,7 +16,7 @@ import {SiteLogDataModel} from '../json-data-view-model/data-model/site-log-data
  */
 @Injectable()
 export class SiteLogService {
-    private savedSubject: Subject<boolean> = new Subject();
+    private isSavedSubject: Subject<null> = new Subject();
 
     private handleXMLData(response: Response): string {
         if (response.status === 200) {
@@ -161,15 +161,15 @@ export class SiteLogService {
      * Inform subscribers when the save action completed successfully.
      */
     private sendSavedMessage() {
-        this.savedSubject.next(true);
+        this.isSavedSubject.next();
     }
 
     /**
      * Method to allow clients to subscribe to know when the siteLog has been saved (successfully)
      * @return {Observable<boolean>}
      */
-    getSavedSubscription(): Observable<boolean> {
-        return this.savedSubject.asObservable();
+    getIsSavedSubscription(): Observable<null> {
+        return this.isSavedSubject.asObservable();
     }
 
     /**
@@ -198,11 +198,6 @@ export class SiteLogService {
         geodesyMl += siteLogML + '</geo:GeodesyML>';
         // console.log('saveSiteLog - geodesyMl: ', geodesyMl);
         console.log('saveSiteLog - geodesyMl (length): ', geodesyMl.length);
-        // return this.http.post(this.constantsService.getWebServiceURL() + '/siteLogs/upload', geodesyMl)
-        //     .map(HttpUtilsService.handleJsonData)
-        //     .catch(HttpUtilsService.handleError);
-        //
-        // ---------
         return new Observable((observer: any) => {
             try {
                 this.http.post(this.constantsService.getWebServiceURL() + '/siteLogs/upload', geodesyMl).subscribe(

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {SurveyedLocalTieViewModel} from './surveyed-local-tie-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Surveyed Local Tie.
@@ -41,8 +42,8 @@ export class SurveyedLocalTieItemComponent extends AbstractItem {
      */
     @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-    constructor(protected dialogService: DialogService) {
-        super(dialogService);
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
     }
 
     getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -1,10 +1,10 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {SurveyedLocalTieViewModel} from './surveyed-local-tie-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { SurveyedLocalTieViewModel } from './surveyed-local-tie-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Surveyed Local Tie.

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {TemperatureSensorViewModel} from './temperature-sensor-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Temperature Sensor.
@@ -41,8 +42,8 @@ export class TemperatureSensorItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService) {
-    super(dialogService);
+  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+      super(dialogService, siteLogService);
   }
 
   getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -1,64 +1,64 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {TemperatureSensorViewModel} from './temperature-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { TemperatureSensorViewModel } from './temperature-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single Temperature Sensor.
  */
 @Component({
-  moduleId: module.id,
-  selector: 'temperature-sensor-item',
-  templateUrl: 'temperature-sensor-item.component.html',
+    moduleId: module.id,
+    selector: 'temperature-sensor-item',
+    templateUrl: 'temperature-sensor-item.component.html',
 })
 export class TemperatureSensorItemComponent extends AbstractItem {
-  public miscUtils: any = MiscUtils;
+    public miscUtils: any = MiscUtils;
 
-  /**
-   * Total number of temperatureSensors
-   */
-  @Input() total: number;
-  /**
-   * The index of this sensor (zero-based)
-   */
-  @Input() index: number;
-  /**
-   * The TemperatureSensor in question.
-   */
-  @Input() temperatureSensor: TemperatureSensorViewModel;
+    /**
+     * Total number of temperatureSensors
+     */
+    @Input() total: number;
+    /**
+     * The index of this sensor (zero-based)
+     */
+    @Input() index: number;
+    /**
+     * The TemperatureSensor in question.
+     */
+    @Input() temperatureSensor: TemperatureSensorViewModel;
 
-  /**
-   * This is to receive geodesyEvent from parent.
-   */
-  @Input() geodesyEvent: GeodesyEvent;
+    /**
+     * This is to receive geodesyEvent from parent.
+     */
+    @Input() geodesyEvent: GeodesyEvent;
 
-  /**
-   * Events children components can send to their parent components.  Usually these are then passed to all
-   * child components.
-   * @type {EventEmitter<boolean>}
-   */
-  @Output() returnEvents = new EventEmitter<GeodesyEvent>();
+    /**
+     * Events children components can send to their parent components.  Usually these are then passed to all
+     * child components.
+     * @type {EventEmitter<boolean>}
+     */
+    @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      super(dialogService, siteLogService);
-  }
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
+    }
 
-  getGeodesyEvent(): GeodesyEvent {
-    return this.geodesyEvent;
-  }
+    getGeodesyEvent(): GeodesyEvent {
+        return this.geodesyEvent;
+    }
 
-  getIndex(): number {
-    return this.index;
-  }
+    getIndex(): number {
+        return this.index;
+    }
 
-  getReturnEvents(): EventEmitter<GeodesyEvent> {
-    return this.returnEvents;
-  }
+    getReturnEvents(): EventEmitter<GeodesyEvent> {
+        return this.returnEvents;
+    }
 
-  getItemName(): string {
-    return 'Temperature Sensor';
-  }
+    getItemName(): string {
+        return 'Temperature Sensor';
+    }
 }

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -4,6 +4,7 @@ import {GeodesyEvent} from '../shared/events-messages/Event';
 import {WaterVaporSensorViewModel} from './water-vapor-sensor-view-model';
 import {MiscUtils} from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
+import {SiteLogService} from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single WaterVapor Sensor.
@@ -41,8 +42,8 @@ export class WaterVaporSensorItemComponent extends AbstractItem {
    */
   @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService) {
-    super(dialogService);
+  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+      super(dialogService, siteLogService);
   }
 
   getGeodesyEvent(): GeodesyEvent {

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -1,64 +1,64 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {WaterVaporSensorViewModel} from './water-vapor-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { WaterVaporSensorViewModel } from './water-vapor-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
-import {SiteLogService} from '../shared/site-log/site-log.service';
+import { SiteLogService } from '../shared/site-log/site-log.service';
 
 /**
  * This component represents a single WaterVapor Sensor.
  */
 @Component({
-  moduleId: module.id,
-  selector: 'water-vapor-sensor-item',
-  templateUrl: 'water-vapor-sensor-item.component.html',
+    moduleId: module.id,
+    selector: 'water-vapor-sensor-item',
+    templateUrl: 'water-vapor-sensor-item.component.html',
 })
 export class WaterVaporSensorItemComponent extends AbstractItem {
-  public miscUtils: any = MiscUtils;
+    public miscUtils: any = MiscUtils;
 
-  /**
-   * Total number of waterVaporSensors
-   */
-  @Input() total: number;
-  /**
-   * The index of this sensor (zero-based)
-   */
-  @Input() index: number;
-  /**
-   * The WaterVaporSensor in question.
-   */
-  @Input() waterVaporSensor: WaterVaporSensorViewModel;
+    /**
+     * Total number of waterVaporSensors
+     */
+    @Input() total: number;
+    /**
+     * The index of this sensor (zero-based)
+     */
+    @Input() index: number;
+    /**
+     * The WaterVaporSensor in question.
+     */
+    @Input() waterVaporSensor: WaterVaporSensorViewModel;
 
-  /**
-   * This is to receive geodesyEvent from parent.
-   */
-  @Input() geodesyEvent: GeodesyEvent;
+    /**
+     * This is to receive geodesyEvent from parent.
+     */
+    @Input() geodesyEvent: GeodesyEvent;
 
-  /**
-   * Events children components can send to their parent components.  Usually these are then passed to all
-   * child components.
-   * @type {EventEmitter<boolean>}
-   */
-  @Output() returnEvents = new EventEmitter<GeodesyEvent>();
+    /**
+     * Events children components can send to their parent components.  Usually these are then passed to all
+     * child components.
+     * @type {EventEmitter<boolean>}
+     */
+    @Output() returnEvents = new EventEmitter<GeodesyEvent>();
 
-  constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
-      super(dialogService, siteLogService);
-  }
+    constructor(protected dialogService: DialogService, protected siteLogService: SiteLogService) {
+        super(dialogService, siteLogService);
+    }
 
-  getGeodesyEvent(): GeodesyEvent {
-    return this.geodesyEvent;
-  }
+    getGeodesyEvent(): GeodesyEvent {
+        return this.geodesyEvent;
+    }
 
-  getIndex(): number {
-    return this.index;
-  }
+    getIndex(): number {
+        return this.index;
+    }
 
-  getReturnEvents(): EventEmitter<GeodesyEvent> {
-    return this.returnEvents;
-  }
+    getReturnEvents(): EventEmitter<GeodesyEvent> {
+        return this.returnEvents;
+    }
 
-  getItemName(): string {
-    return 'Water Vapor Sensor';
-  }
+    getItemName(): string {
+        return 'Water Vapor Sensor';
+    }
 }


### PR DESCRIPTION
Eg. when create a new Humidity Sensor

* New items can be 'cancelled' has they haven't yet been saved
* Fixed a bug where this didn't change to 'delete' after the save
* Added subscription to a Subject on the SiteLogService
* Unfortunately to add dependency to the AbstractItems base class had to add to child classes and pass in `super()` (I thought this was changing in NG 2.3 - inheritance changed - https://medium.com/@amcdnl/inheritance-in-angular2-components-206a167fc259#.twex1bbar - but not this aspect of it)