### PR TITLE
Fix "Notes" field clipping issue

### DIFF
--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -339,6 +339,7 @@ form .ng-invalid {
   padding: 0 8px !important;
   width: 100%;
   font-size: 14px;
+  height: 60px;
   line-height: 1.42857143;
   color: #555;
   background-color: #fff;


### PR DESCRIPTION
Added  a height property to all text-area field so that their height will be fixed showing 3 rows in all browsers.