### PR TITLE
IntelliJ Code Format for Typescript

### DIFF
--- a/intellij-ts-code-format.xml
+++ b/intellij-ts-code-format.xml
@@ -1,0 +1,12 @@
+<code_scheme name="Default (1)">
+  <option name="AUTODETECT_INDENTS" value="false" />
+  <option name="RIGHT_MARGIN" value="140" />
+  <option name="HTML_KEEP_LINE_BREAKS" value="false" />
+  <option name="HTML_KEEP_LINE_BREAKS_IN_TEXT" value="false" />
+  <option name="HTML_ALIGN_TEXT" value="true" />
+  <option name="HTML_ENFORCE_QUOTES" value="true" />
+  <TypeScriptCodeStyleSettings>
+    <option name="USE_DOUBLE_QUOTES" value="false" />
+    <option name="SPACES_WITHIN_IMPORTS" value="true" />
+  </TypeScriptCodeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
* Incluces spaces inside import braces eg { abc }.
* Devs will need to import this