### PR TITLE
Rm warning msg

### DIFF
--- a/src/client/app/app.component.ts
+++ b/src/client/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component, ViewContainerRef } from '@angular/core';
 import { Config, CorsSiteService, CorsSetupService, SiteLogService, DialogService, MiscUtils,
-          JsonDiffService, JsonCheckService, JsonPointerService, NameListService, ServiceWorkerService,
-          JsonixService } from './shared/index';
+         JsonDiffService, JsonCheckService, JsonPointerService, NameListService, ServiceWorkerService,
+         JsonixService } from './shared/index';
 import { SiteInfoComponent } from './site-info/site-info.component';
-import {JsonViewModelService} from './shared/json-data-view-model/json-view-model.service';
+import { JsonViewModelService } from './shared/json-data-view-model/json-view-model.service';
 
 /**
  * This class represents the main application component. Within the @Routes annotation is the configuration of the

--- a/src/client/app/frequency-standard/frequency-standard-group.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {FrequencyStandardViewModel} from './frequency-standard-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { FrequencyStandardViewModel } from './frequency-standard-view-model';
 
 /**
  * This class represents a collection of FrequencyStandard Component.

--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {FrequencyStandardViewModel} from './frequency-standard-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { FrequencyStandardViewModel } from './frequency-standard-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/frequency-standard/frequency-standard-view-model.ts
+++ b/src/client/app/frequency-standard/frequency-standard-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class FrequencyStandardViewModel extends AbstractViewModel {
   public startDate: string;

--- a/src/client/app/gnss-antenna/gnss-antenna-group.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {GnssAntennaViewModel} from './gnss-antenna-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { GnssAntennaViewModel } from './gnss-antenna-view-model';
 
 /**
  * This class represents a collection of GNSS Antenna items.

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {GnssAntennaViewModel} from './gnss-antenna-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { GnssAntennaViewModel } from './gnss-antenna-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/gnss-antenna/gnss-antenna-view-model.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class GnssAntennaViewModel extends AbstractViewModel {
 

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {GnssReceiverViewModel} from './gnss-receiver-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { GnssReceiverViewModel } from './gnss-receiver-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/gnss-receiver/gnss-receiver-view-model.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class GnssReceiverViewModel extends AbstractViewModel {
     /**

--- a/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {GnssReceiverViewModel} from './gnss-receiver-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { GnssReceiverViewModel } from './gnss-receiver-view-model';
 
 /**.
  * This class represents a group of GNSS Receivers.

--- a/src/client/app/home/home.component.ts
+++ b/src/client/app/home/home.component.ts
@@ -77,7 +77,7 @@ export class HomeComponent implements OnInit {
     }, (error: Error) => {
       throw new Error('Error in clearCache: '+ error.message);
     });
-  };
+  }
 
   updateCacheList=() => {
     this.serviceWorkerService.getCacheList().then((data: string[]) => {
@@ -89,5 +89,5 @@ export class HomeComponent implements OnInit {
     }).catch((error: any) => {
       console.error('Caught error in updateCacheList:', error);
     });
-  };
+  }
 }

--- a/src/client/app/home/home.component.ts
+++ b/src/client/app/home/home.component.ts
@@ -1,7 +1,7 @@
-import {Component, OnInit} from '@angular/core';
-import {Subscription} from 'rxjs/Subscription';
-import {NameListService} from '../shared/index';
-import {ServiceWorkerService} from '../shared/index';
+import { Component, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs/Subscription';
+import { NameListService } from '../shared/index';
+import { ServiceWorkerService } from '../shared/index';
 
 /**
  * This class represents the lazy loaded HomeComponent.

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {HumiditySensorViewModel} from './humidity-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { HumiditySensorViewModel } from './humidity-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
@@ -1,5 +1,5 @@
-import {HumiditySensorViewModel} from './humidity-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { HumiditySensorViewModel } from './humidity-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 export function main() {
   let humiditySensorsViewModel: HumiditySensorViewModel;
 

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class HumiditySensorViewModel extends AbstractViewModel {
     /**

--- a/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {HumiditySensorViewModel} from './humidity-sensor-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { HumiditySensorViewModel } from './humidity-sensor-view-model';
 
 /**.
  * This class represents a group of Humidity Sensors.

--- a/src/client/app/local-episodic-event/local-episodic-event-item.component.ts
+++ b/src/client/app/local-episodic-event/local-episodic-event-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {LocalEpisodicEventViewModel} from './local-episodic-event-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { LocalEpisodicEventViewModel } from './local-episodic-event-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/local-episodic-event/local-episodic-event-view-model.spec.ts
+++ b/src/client/app/local-episodic-event/local-episodic-event-view-model.spec.ts
@@ -1,5 +1,5 @@
-import {LocalEpisodicEventViewModel} from './local-episodic-event-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { LocalEpisodicEventViewModel } from './local-episodic-event-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 export function main() {
   let localEpisodicEventViewModel: LocalEpisodicEventViewModel;
 

--- a/src/client/app/local-episodic-event/local-episodic-event-view-model.ts
+++ b/src/client/app/local-episodic-event/local-episodic-event-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class LocalEpisodicEventViewModel extends AbstractViewModel {
     /**

--- a/src/client/app/local-episodic-event/local-episodic-events-group.component.ts
+++ b/src/client/app/local-episodic-event/local-episodic-events-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {LocalEpisodicEventViewModel} from './local-episodic-event-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { LocalEpisodicEventViewModel } from './local-episodic-event-view-model';
 
 /**.
  * This class represents a group of Local Episodic Effects.

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {PressureSensorViewModel} from './pressure-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { PressureSensorViewModel } from './pressure-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
@@ -1,5 +1,5 @@
-import {PressureSensorViewModel} from './pressure-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { PressureSensorViewModel } from './pressure-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 export function main() {
   let pressureSensorsViewModel: PressureSensorViewModel;
 

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class PressureSensorViewModel extends AbstractViewModel {
   /**

--- a/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {PressureSensorViewModel} from './pressure-sensor-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { PressureSensorViewModel } from './pressure-sensor-view-model';
 
 /**
  * This class represents a group of Pressure Sensors.

--- a/src/client/app/responsible-party/responsible-party.component.ts
+++ b/src/client/app/responsible-party/responsible-party.component.ts
@@ -56,7 +56,7 @@ export class ResponsiblePartyComponent implements OnInit {
     }).catch((error: any) => {
       console.error('Caught error in updateCacheList:', error);
     });
-  };
+  }
 
   /**
    * Add a new empty responsible party

--- a/src/client/app/responsible-party/responsible-party.component.ts
+++ b/src/client/app/responsible-party/responsible-party.component.ts
@@ -17,16 +17,17 @@ import { ConstantsService, MiscUtils, JsonCheckService, ServiceWorkerService } f
   templateUrl: 'responsible-party.component.html',
 })
 export class ResponsiblePartyComponent implements OnInit {
-  private serviceWorkerSubscription: Subscription;
   public errorMessage: string;
-  private cacheItems: Array<string> = [];
-  private isPartyGroupOpen: boolean = false;
   public miscUtils: any = MiscUtils;
   @Input() partyName: string;
   @Input() responsibleParties: any;
   @Input() dataModel: any;
   @Input() dataModelCopy: any;
   @Input() status: any;
+
+  private serviceWorkerSubscription: Subscription;
+  private cacheItems: Array<string> = [];
+  private isPartyGroupOpen: boolean = false;
 
   constructor(private jsonCheckService: JsonCheckService,
               private serviceWorkerService: ServiceWorkerService) { }

--- a/src/client/app/responsible-party/responsible-party.component.ts
+++ b/src/client/app/responsible-party/responsible-party.component.ts
@@ -19,6 +19,7 @@ import { ConstantsService, MiscUtils, JsonCheckService, ServiceWorkerService } f
 export class ResponsiblePartyComponent implements OnInit {
   public errorMessage: string;
   public miscUtils: any = MiscUtils;
+  public isPartyGroupOpen: boolean = false;
   @Input() partyName: string;
   @Input() responsibleParties: any;
   @Input() dataModel: any;
@@ -27,7 +28,6 @@ export class ResponsiblePartyComponent implements OnInit {
 
   private serviceWorkerSubscription: Subscription;
   private cacheItems: Array<string> = [];
-  private isPartyGroupOpen: boolean = false;
 
   constructor(private jsonCheckService: JsonCheckService,
               private serviceWorkerService: ServiceWorkerService) { }

--- a/src/client/app/responsible-party/responsible-party.component.ts
+++ b/src/client/app/responsible-party/responsible-party.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit, Input} from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 import { ConstantsService, MiscUtils, JsonCheckService, ServiceWorkerService } from '../shared/index';
 

--- a/src/client/app/select-site/select-site.component.ts
+++ b/src/client/app/select-site/select-site.component.ts
@@ -14,6 +14,11 @@ import { DialogService, CorsSiteService, ServiceWorkerService } from '../shared/
   templateUrl: 'select-site.component.html',
 })
 export class SelectSiteComponent implements OnInit {
+  public columns: Array<any> = [
+    {name: 'fourCharacterId', sort: ''},
+    {name: 'name', sort: ''}
+  ];
+
   private serviceWorkerSubscription: Subscription;
   private searchTextSubject = new Subject<string>();
   private searchText: string = '';
@@ -23,12 +28,6 @@ export class SelectSiteComponent implements OnInit {
   private errorMessage: string;
   private isSearching: boolean = false;
   private cacheItems: Array<string> = [];
-
-  public columns: Array<any> = [
-    {name: 'fourCharacterId', sort: ''},
-    {name: 'name', sort: ''}
-  ];
-
 
   /**
    * Creates an instance of the SelectSiteComponent with the injected CorsSiteService.

--- a/src/client/app/shared/abstract-groups-items/abstract-group.spec.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.spec.ts
@@ -1,5 +1,5 @@
-import {AbstractGroup} from './abstract-group';
-import {AbstractViewModel} from '../json-data-view-model/view-model/abstract-view-model';
+import { AbstractGroup } from './abstract-group';
+import { AbstractViewModel } from '../json-data-view-model/view-model/abstract-view-model';
 
 class AbstractViewModelImpl extends AbstractViewModel {
     public startDate: string;

--- a/src/client/app/shared/abstract-groups-items/abstract-group.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.ts
@@ -80,15 +80,6 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
     abstract compare(obj1: AbstractViewModel, obj2: AbstractViewModel): number;
 
     /**
-     * Use the Geodesy object defined comparator in compare() to sort the given collection inline.
-     *
-     * @param collection
-     */
-    private sortUsingComparator(collection: any[]) {
-        collection.sort(this.compare);
-    }
-
-    /**
      * Event mechanism to communicate with children.  Simply change the value of this and the children detect the change.
      *
      * @returns {GeodesyEvent}
@@ -124,10 +115,6 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
         } else {
             return [];
         }
-    }
-
-    private isntDeleted(item: T): boolean {
-        return (!item.dateDeleted || item.dateDeleted.length === 0);
     }
 
     getItemsOriginalCollection(): T[] {
@@ -180,16 +167,6 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
     }
 
     /**
-     * After a new item is created 'EventNames.newItem' is sent so that item can init itself.
-     */
-    private newItemEvent() {
-        console.log('parent newItemEvent');
-        let geodesyEvent: GeodesyEvent = this.getGeodesyEvent();
-        geodesyEvent.name = EventNames.newItem;
-        geodesyEvent.valueNumber = 0;
-    }
-
-    /**
      * Remove an item.  Originally it was removed from the list.  However we now want to track deletes so
      * keep it and mark as deleted using change tracking.
      */
@@ -211,6 +188,29 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
         // (high to low start date).  Thus to access the original dataItems we need to reverse the index.
         let newIndex: number = this.itemProperties.length - itemIndex - 1;
         this.itemProperties.splice(newIndex, 1);
+    }
+
+    /**
+     * Use the Geodesy object defined comparator in compare() to sort the given collection inline.
+     *
+     * @param collection
+     */
+    private sortUsingComparator(collection: any[]) {
+        collection.sort(this.compare);
+    }
+
+    private isntDeleted(item: T): boolean {
+        return (!item.dateDeleted || item.dateDeleted.length === 0);
+    }
+
+    /**
+     * After a new item is created 'EventNames.newItem' is sent so that item can init itself.
+     */
+    private newItemEvent() {
+        console.log('parent newItemEvent');
+        let geodesyEvent: GeodesyEvent = this.getGeodesyEvent();
+        geodesyEvent.name = EventNames.newItem;
+        geodesyEvent.valueNumber = 0;
     }
 
     private setDeleted(item: T) {

--- a/src/client/app/shared/abstract-groups-items/abstract-group.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.ts
@@ -1,5 +1,5 @@
-import {GeodesyEvent, EventNames} from '../events-messages/Event';
-import {AbstractViewModel} from '../json-data-view-model/view-model/abstract-view-model';
+import { GeodesyEvent, EventNames } from '../events-messages/Event';
+import { AbstractViewModel } from '../json-data-view-model/view-model/abstract-view-model';
 import * as lodash from 'lodash';
 
 export abstract class AbstractGroup<T extends AbstractViewModel> {

--- a/src/client/app/shared/abstract-groups-items/abstract-item.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.ts
@@ -73,28 +73,6 @@ export abstract class AbstractItem implements DoCheck, OnInit {
     }
 
     /**
-     * Event Handler - if this item has the given indexOfNew, then this is a new item.
-     *
-     * @param indexOfNew
-     */
-    private newItem(indexOfNew: number) {
-        if (this.getIndex() === indexOfNew) {
-            this.isNew = true;
-            this.isOpen = true;
-        }
-    }
-
-    /**
-     * Keep a lastGeodesyEvent so can see in ngDoCheck() if the event has changed
-     */
-    private copyEventToLast() {
-        this.lastGeodesyEvent.name = this.getGeodesyEvent().name;
-        this.lastGeodesyEvent.valueNumber = this.getGeodesyEvent().valueNumber;
-        this.lastGeodesyEvent.valueObject = this.getGeodesyEvent().valueObject;
-        this.lastGeodesyEvent.valueString = this.getGeodesyEvent().valueString;
-    }
-
-    /**
      * Remove an item from the UI and delete if it is an existing record.
      */
     removeItem(index: number) {
@@ -118,6 +96,32 @@ export abstract class AbstractItem implements DoCheck, OnInit {
       }
     }
 
+    getRemoveOrDeletedText(): string {
+        return this.isNew ? 'Cancel' : 'Delete';
+    }
+
+    /**
+     * Event Handler - if this item has the given indexOfNew, then this is a new item.
+     *
+     * @param indexOfNew
+     */
+    private newItem(indexOfNew: number) {
+        if (this.getIndex() === indexOfNew) {
+            this.isNew = true;
+            this.isOpen = true;
+        }
+    }
+
+    /**
+     * Keep a lastGeodesyEvent so can see in ngDoCheck() if the event has changed
+     */
+    private copyEventToLast() {
+        this.lastGeodesyEvent.name = this.getGeodesyEvent().name;
+        this.lastGeodesyEvent.valueNumber = this.getGeodesyEvent().valueNumber;
+        this.lastGeodesyEvent.valueObject = this.getGeodesyEvent().valueObject;
+        this.lastGeodesyEvent.valueString = this.getGeodesyEvent().valueString;
+    }
+
     /**
      *  Mark an item for deletion using the specified reason.
      */
@@ -134,9 +138,5 @@ export abstract class AbstractItem implements DoCheck, OnInit {
         console.log('child call cancelNew(' + index + ')');
         let geodesyEvent: GeodesyEvent = {name: EventNames.cancelNew, valueNumber: index, valueString: deleteReason};
         this.getReturnEvents().emit(geodesyEvent);
-    }
-
-    getRemoveOrDeletedText(): string {
-        return this.isNew ? 'Cancel' : 'Delete';
     }
 }

--- a/src/client/app/shared/cors-site/cors-site.service.ts
+++ b/src/client/app/shared/cors-site/cors-site.service.ts
@@ -43,18 +43,6 @@ export class CorsSiteService {
         });
   }
 
-  private fixWFSeData(wfsData: any): any {
-    // TODO - make this data an Interface
-    console.debug('cors-site service - from wfsService - fixWFSeData - data: ', wfsData);
-    let fieldsDefined: any[] = [];
-    wfsData.map((wfsFormat:any) => {
-      let name: string = wfsFormat['geo:Site'].hasOwnProperty('name') ? wfsFormat['geo:Site'].name[0].value : 'no name';
-      fieldsDefined.push({'fourCharacterId':wfsFormat['geo:Site'].identifier.value, 'name': name});
-    });
-    console.debug('cors-site service - from wfsService - fixWFSeData - return: ', fieldsDefined);
-    return fieldsDefined; //data;
-  }
-
   /**
    * Returns an Observable for the HTTP GET request for all records available from the Site table.
    * @return {object[]} The Observable for the HTTP request.
@@ -69,5 +57,17 @@ export class CorsSiteService {
     return this.http.get(this.constantsService.getWebServiceURL() + '/corsSites?id=' + id)
       .map(HttpUtilsService.handleJsonData)
       .catch(HttpUtilsService.handleError);
+  }
+
+  private fixWFSeData(wfsData: any): any {
+    // TODO - make this data an Interface
+    console.debug('cors-site service - from wfsService - fixWFSeData - data: ', wfsData);
+    let fieldsDefined: any[] = [];
+    wfsData.map((wfsFormat:any) => {
+      let name: string = wfsFormat['geo:Site'].hasOwnProperty('name') ? wfsFormat['geo:Site'].name[0].value : 'no name';
+      fieldsDefined.push({'fourCharacterId':wfsFormat['geo:Site'].identifier.value, 'name': name});
+    });
+    console.debug('cors-site service - from wfsService - fixWFSeData - return: ', fieldsDefined);
+    return fieldsDefined; //data;
   }
 }

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -13,6 +13,14 @@ import { MiscUtils } from '../index';
 export class DatetimeInputComponent implements OnInit, DoCheck {
   public miscUtils: any = MiscUtils;
   public datetimeModel: Date;
+  @Input() public index: any = 0;
+  @Input() public datetime: string = '';
+  @Input() public name: string = 'Date';
+  @Input() public required: boolean = false;
+  @Input() public requiredIfNotCurrent: boolean = false;
+  @Input() public label: string = '';
+  @Output() public datetimeChange: EventEmitter<string> = new EventEmitter<string>();
+
   private datetimeDisplay: string = '';
   private datetimeSuffix: string = '.000Z';
   private hours: number = 0;
@@ -27,14 +35,6 @@ export class DatetimeInputComponent implements OnInit, DoCheck {
   private invalidDatetime: boolean = false;
   private showDatetimePicker: boolean = false;
   private datetimeLast: string = '';
-
-  @Input() public index: any = 0;
-  @Input() public datetime: string = '';
-  @Input() public name: string = 'Date';
-  @Input() public required: boolean = false;
-  @Input() public requiredIfNotCurrent: boolean = false;
-  @Input() public label: string = '';
-  @Output() public datetimeChange: EventEmitter<string> = new EventEmitter<string>();
 
   constructor(private elemRef: ElementRef) { }
 
@@ -253,6 +253,26 @@ export class DatetimeInputComponent implements OnInit, DoCheck {
     }
   }
 
+  public isRequired() : boolean {
+    return this.required || (this.requiredIfNotCurrent && this.index[0] !== 0);
+  }
+
+  /**
+   * Get a validation message to apply if the input string is:
+   *   1. required but not supplied, or
+   *   2. supplied but not a valid date
+   */
+  public getValidationMessage() {
+    let message = this.label + ' is ';
+    if (this.isRequired() && !this.datetimeDisplay) {
+      message += ' required ';
+    } else if (this.invalidDatetime) {
+      message += ' not valid ';
+    }
+    message += '(Valid Date Format: YYYY-MM-DD hh:mm:ss)';
+    return message;
+  }
+
   /**
    * Update hour/minute/second time strings in response to any changes in hours, minutes, and seconds.
    */
@@ -348,25 +368,5 @@ export class DatetimeInputComponent implements OnInit, DoCheck {
       return '0' + index.toString();
     }
     return index.toString();
-  }
-
-  public isRequired() : boolean {
-    return this.required || (this.requiredIfNotCurrent && this.index[0] !== 0);
-  }
-
-  /**
-   * Get a validation message to apply if the input string is:
-   *   1. required but not supplied, or
-   *   2. supplied but not a valid date
-   */
-  public getValidationMessage() {
-    let message = this.label + ' is ';
-    if (this.isRequired() && !this.datetimeDisplay) {
-      message += ' required ';
-    } else if (this.invalidDatetime) {
-      message += ' not valid ';
-    }
-    message += '(Valid Date Format: YYYY-MM-DD hh:mm:ss)';
-    return message;
   }
 }

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -13,6 +13,15 @@ import { MiscUtils } from '../index';
 export class DatetimeInputComponent implements OnInit, DoCheck {
   public miscUtils: any = MiscUtils;
   public datetimeModel: Date;
+  public datetimeDisplay: string = '';
+  public hoursString: string = '00';
+  public minutesString: string = '00';
+  public secondsString: string = '00';
+  public invalidHours: boolean = false;
+  public invalidMinutes: boolean = false;
+  public invalidSeconds: boolean = false;
+  public invalidDatetime: boolean = false;
+  public showDatetimePicker: boolean = false;
   @Input() public index: any = 0;
   @Input() public datetime: string = '';
   @Input() public name: string = 'Date';
@@ -21,19 +30,10 @@ export class DatetimeInputComponent implements OnInit, DoCheck {
   @Input() public label: string = '';
   @Output() public datetimeChange: EventEmitter<string> = new EventEmitter<string>();
 
-  private datetimeDisplay: string = '';
-  private datetimeSuffix: string = '.000Z';
   private hours: number = 0;
   private minutes: number = 0;
   private seconds: number = 0;
-  private hoursString: string = '00';
-  private minutesString: string = '00';
-  private secondsString: string = '00';
-  private invalidHours: boolean = false;
-  private invalidMinutes: boolean = false;
-  private invalidSeconds: boolean = false;
-  private invalidDatetime: boolean = false;
-  private showDatetimePicker: boolean = false;
+  private datetimeSuffix: string = '.000Z';
   private datetimeLast: string = '';
 
   constructor(private elemRef: ElementRef) { }

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, DoCheck} from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Input, OnInit, Output, DoCheck } from '@angular/core';
 import { MiscUtils } from '../index';
 
 /**

--- a/src/client/app/shared/dynamic-form-fields/number-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/number-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   moduleId: module.id,

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   moduleId: module.id,

--- a/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
 
 @Component({
   moduleId: module.id,

--- a/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
@@ -13,6 +13,7 @@ export class TextAreaInputComponent {
   @Input() public label: string = '';
   @Input() public required: boolean = false;
   @Input() public rows: string = '';
+  @Input() public minlength: string = '';
   @Input() public maxlength: string = '';
 
   configurationObject: any = null;

--- a/src/client/app/shared/global/json-diff.service.spec.ts
+++ b/src/client/app/shared/global/json-diff.service.spec.ts
@@ -1,12 +1,12 @@
-import {ReflectiveInjector} from '@angular/core';
-import {BaseRequestOptions, ConnectionBackend, Http} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
+import { ReflectiveInjector } from '@angular/core';
+import { BaseRequestOptions, ConnectionBackend, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
 import * as lodash from 'lodash';
 
-import {JsonDiffService, DiffItem, DiffType, NormalisedDiffs} from './json-diff.service';
-import {HttpUtilsService} from './http-utils.service';
-import {MiscUtils} from './misc-utils';
-import {HumiditySensorViewModel} from '../../humidity-sensor/humidity-sensor-view-model';
+import { JsonDiffService, DiffItem, DiffType, NormalisedDiffs } from './json-diff.service';
+import { HttpUtilsService } from './http-utils.service';
+import { MiscUtils } from './misc-utils';
+import { HumiditySensorViewModel } from '../../humidity-sensor/humidity-sensor-view-model';
 
 export function main() {
   describe('Json Diff Service', () => {

--- a/src/client/app/shared/global/json-diff.service.ts
+++ b/src/client/app/shared/global/json-diff.service.ts
@@ -1,9 +1,9 @@
-import {Injectable} from '@angular/core';
-import {HttpUtilsService} from './http-utils.service';
-import {MiscUtils} from './misc-utils';
+import { Injectable } from '@angular/core';
+import { HttpUtilsService } from './http-utils.service';
+import { MiscUtils } from './misc-utils';
 import * as diff from 'deep-diff';
 import IDiff = deepDiff.IDiff;
-import {JsonPointerService} from '../json-pointer/json-pointer.service';
+import { JsonPointerService } from '../json-pointer/json-pointer.service';
 
 /**
  * JSON Differencing service using https://github.com/flitbit/diff.

--- a/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
@@ -1,8 +1,8 @@
-import {SiteLogDataModel} from './data-model/site-log-data-model';
-import {DataViewTranslatorService} from './data-view-translator';
-import {JsonViewModelServiceSpecData} from './json-view-model.service.spec.data';
-import {FieldMaps} from './field-maps';
-import {HumiditySensorViewModel} from '../../humidity-sensor/humidity-sensor-view-model';
+import { SiteLogDataModel } from './data-model/site-log-data-model';
+import { DataViewTranslatorService } from './data-view-translator';
+import { JsonViewModelServiceSpecData } from './json-view-model.service.spec.data';
+import { FieldMaps } from './field-maps';
+import { HumiditySensorViewModel } from '../../humidity-sensor/humidity-sensor-view-model';
 
 export function main() {
   let completeValidSitelog: any = JsonViewModelServiceSpecData.data();

--- a/src/client/app/shared/json-data-view-model/data-view-translator.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.ts
@@ -1,7 +1,7 @@
-import {JsonPointerService} from '../json-pointer/json-pointer.service';
-import {FieldMaps} from './field-maps';
-import {TypedPointer} from './typed-pointer';
-import {AbstractViewModel} from './view-model/abstract-view-model';
+import { JsonPointerService } from '../json-pointer/json-pointer.service';
+import { FieldMaps } from './field-maps';
+import { TypedPointer } from './typed-pointer';
+import { AbstractViewModel } from './view-model/abstract-view-model';
 
 export class DataViewTranslatorService {
 

--- a/src/client/app/shared/json-data-view-model/field-maps.ts
+++ b/src/client/app/shared/json-data-view-model/field-maps.ts
@@ -1,4 +1,4 @@
-import {TypedPointer} from './typed-pointer';
+import { TypedPointer } from './typed-pointer';
 
 /**
  * Mapping to assist in mapping data model to view model by linking both sides.

--- a/src/client/app/shared/json-data-view-model/json-view-model.service.spec.ts
+++ b/src/client/app/shared/json-data-view-model/json-view-model.service.spec.ts
@@ -1,10 +1,10 @@
-import {ReflectiveInjector} from '@angular/core';
-import {BaseRequestOptions, Http} from '@angular/http';
-import {MockBackend} from '@angular/http/testing';
-import {JsonViewModelService} from './json-view-model.service';
-import {JsonViewModelServiceSpecData} from './json-view-model.service.spec.data';
-import {SiteLogViewModel} from './view-model/site-log-view-model';
-import {SiteLogDataModel} from './data-model/site-log-data-model';
+import { ReflectiveInjector } from '@angular/core';
+import { BaseRequestOptions, Http } from '@angular/http';
+import { MockBackend } from '@angular/http/testing';
+import { JsonViewModelService } from './json-view-model.service';
+import { JsonViewModelServiceSpecData } from './json-view-model.service.spec.data';
+import { SiteLogViewModel } from './view-model/site-log-view-model';
+import { SiteLogDataModel } from './data-model/site-log-data-model';
 
 export function main() {
   let backend: MockBackend = null;

--- a/src/client/app/shared/json-data-view-model/json-view-model.service.ts
+++ b/src/client/app/shared/json-data-view-model/json-view-model.service.ts
@@ -1,18 +1,18 @@
-import {Injectable} from '@angular/core';
-import {SiteLogDataModel} from './data-model/site-log-data-model';
-import {GnssAntennaViewModel} from '../../gnss-antenna/gnss-antenna-view-model';
-import {GnssReceiverViewModel} from '../../gnss-receiver/gnss-receiver-view-model';
-import {SurveyedLocalTieViewModel} from '../../surveyed-local-tie/surveyed-local-tie-view-model';
-import {FrequencyStandardViewModel} from '../../frequency-standard/frequency-standard-view-model';
-import {LocalEpisodicEventViewModel} from '../../local-episodic-event/local-episodic-event-view-model';
-import {HumiditySensorViewModel} from '../../humidity-sensor/humidity-sensor-view-model';
-import {PressureSensorViewModel} from '../../pressure-sensor/pressure-sensor-view-model';
-import {TemperatureSensorViewModel} from '../../temperature-sensor/temperature-sensor-view-model';
-import {WaterVaporSensorViewModel} from '../../water-vapor-sensor/water-vapor-sensor-view-model';
-import {SiteLogViewModel, ViewSiteLog} from './view-model/site-log-view-model';
-import {AbstractViewModel} from './view-model/abstract-view-model';
-import {DataViewTranslatorService} from './data-view-translator';
-import {FieldMaps} from './field-maps';
+import { Injectable } from '@angular/core';
+import { SiteLogDataModel } from './data-model/site-log-data-model';
+import { GnssAntennaViewModel } from '../../gnss-antenna/gnss-antenna-view-model';
+import { GnssReceiverViewModel } from '../../gnss-receiver/gnss-receiver-view-model';
+import { SurveyedLocalTieViewModel } from '../../surveyed-local-tie/surveyed-local-tie-view-model';
+import { FrequencyStandardViewModel } from '../../frequency-standard/frequency-standard-view-model';
+import { LocalEpisodicEventViewModel } from '../../local-episodic-event/local-episodic-event-view-model';
+import { HumiditySensorViewModel } from '../../humidity-sensor/humidity-sensor-view-model';
+import { PressureSensorViewModel } from '../../pressure-sensor/pressure-sensor-view-model';
+import { TemperatureSensorViewModel } from '../../temperature-sensor/temperature-sensor-view-model';
+import { WaterVaporSensorViewModel } from '../../water-vapor-sensor/water-vapor-sensor-view-model';
+import { SiteLogViewModel, ViewSiteLog } from './view-model/site-log-view-model';
+import { AbstractViewModel } from './view-model/abstract-view-model';
+import { DataViewTranslatorService } from './data-view-translator';
+import { FieldMaps } from './field-maps';
 
 /**
  * This class provides the service to convert from 'Geodesy data model JSON' (from the XML via Jsonix) to

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -1,6 +1,6 @@
-import {FieldMaps, FieldMap} from '../field-maps';
-import {TypedPointer} from '../typed-pointer';
-import {MiscUtils} from '../../global/misc-utils';
+import { FieldMaps, FieldMap } from '../field-maps';
+import { TypedPointer } from '../typed-pointer';
+import { MiscUtils } from '../../global/misc-utils';
 
 export abstract class AbstractViewModel {
     // Base Fields

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -46,14 +46,6 @@ export abstract class AbstractViewModel {
         this.fieldMaps.add(new FieldMap(dataTypePointer, viewTypePointer));
     }
 
-    private assertCorrect(dataPath: string, dataPathType: string, viewPath: string, viewPathType: string) {
-      // TODO: where is assert? They should be in a unit test anyway.
-        // assert(dataPath.match(/\/.*/));
-        // assert(dataPathType.match(/number|string/));
-        // assert(viewPath.match(/\/.*/));
-        // assert(viewPathType.match(/number|string/));
-    }
-
     /**
      * Setup common field mappings
      */
@@ -94,4 +86,12 @@ export abstract class AbstractViewModel {
      * Called on the 'last' object before creating a new one to populate it with some values such as endDate.
      */
     abstract setFinalValuesBeforeCreatingNewItem(): void;
+
+    private assertCorrect(dataPath: string, dataPathType: string, viewPath: string, viewPathType: string) {
+      // TODO: where is assert? They should be in a unit test anyway.
+        // assert(dataPath.match(/\/.*/));
+        // assert(dataPathType.match(/number|string/));
+        // assert(viewPath.match(/\/.*/));
+        // assert(viewPathType.match(/number|string/));
+    }
 }

--- a/src/client/app/shared/json-data-view-model/view-model/site-log-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/site-log-view-model.ts
@@ -1,10 +1,10 @@
-import {GnssAntennaViewModel} from '../../../gnss-antenna/gnss-antenna-view-model';
-import {SurveyedLocalTieViewModel} from '../../../surveyed-local-tie/surveyed-local-tie-view-model';
-import {FrequencyStandardViewModel} from '../../../frequency-standard/frequency-standard-view-model';
-import {LocalEpisodicEventViewModel} from '../../../local-episodic-event/local-episodic-event-view-model';
-import {HumiditySensorViewModel} from '../../../humidity-sensor/humidity-sensor-view-model';
-import {PressureSensorViewModel} from '../../../pressure-sensor/pressure-sensor-view-model';
-import {TemperatureSensorViewModel} from '../../../temperature-sensor/temperature-sensor-view-model';
+import { GnssAntennaViewModel } from '../../../gnss-antenna/gnss-antenna-view-model';
+import { SurveyedLocalTieViewModel } from '../../../surveyed-local-tie/surveyed-local-tie-view-model';
+import { FrequencyStandardViewModel } from '../../../frequency-standard/frequency-standard-view-model';
+import { LocalEpisodicEventViewModel } from '../../../local-episodic-event/local-episodic-event-view-model';
+import { HumiditySensorViewModel } from '../../../humidity-sensor/humidity-sensor-view-model';
+import { PressureSensorViewModel } from '../../../pressure-sensor/pressure-sensor-view-model';
+import { TemperatureSensorViewModel } from '../../../temperature-sensor/temperature-sensor-view-model';
 
 /**
  * View Model equivalent of ../data-model/SiteLogDataModel

--- a/src/client/app/shared/json-pointer/json-pointer.service.spec.ts
+++ b/src/client/app/shared/json-pointer/json-pointer.service.spec.ts
@@ -1,4 +1,4 @@
-import {JsonPointerService} from './json-pointer.service';
+import { JsonPointerService } from './json-pointer.service';
 
 
 export function main() {

--- a/src/client/app/shared/json-pointer/json-pointer.service.ts
+++ b/src/client/app/shared/json-pointer/json-pointer.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import { Injectable } from '@angular/core';
 import * as JsonPointer from 'json-pointer';
 
 @Injectable()

--- a/src/client/app/shared/jsonix/jsonix.service.ts
+++ b/src/client/app/shared/jsonix/jsonix.service.ts
@@ -1,4 +1,4 @@
-import {Injectable} from '@angular/core';
+import { Injectable } from '@angular/core';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 

--- a/src/client/app/shared/service-worker/service-worker.service.ts
+++ b/src/client/app/shared/service-worker/service-worker.service.ts
@@ -7,10 +7,10 @@ import { MessageObject } from './messages.interface';
  */
 @Injectable()
 export class ServiceWorkerService {
+  // Setup Observables (BehaviorSubject's to be specific) to communicate between components
+  protected clearCacheFlag = new BehaviorSubject<boolean>(false);
   // Observable
   public clearCacheObservable = this.clearCacheFlag.asObservable();
-  // Setup Observables (BehaviorSubject's to be specific) to communicate between components
-  private clearCacheFlag = new BehaviorSubject<boolean>(false);
 
   /**
    *

--- a/src/client/app/shared/service-worker/service-worker.service.ts
+++ b/src/client/app/shared/service-worker/service-worker.service.ts
@@ -7,10 +7,10 @@ import { MessageObject } from './messages.interface';
  */
 @Injectable()
 export class ServiceWorkerService {
-  // Setup Observables (BehaviorSubject's to be specific) to communicate between components
-  private clearCacheFlag = new BehaviorSubject<boolean>(false);
   // Observable
   public clearCacheObservable = this.clearCacheFlag.asObservable();
+  // Setup Observables (BehaviorSubject's to be specific) to communicate between components
+  private clearCacheFlag = new BehaviorSubject<boolean>(false);
 
   /**
    *

--- a/src/client/app/shared/site-log/site-log.service.ts
+++ b/src/client/app/shared/site-log/site-log.service.ts
@@ -16,17 +16,6 @@ import { SiteLogDataModel } from '../json-data-view-model/data-model/site-log-da
  */
 @Injectable()
 export class SiteLogService {
-    private handleXMLData(response: Response): string {
-        if (response.status === 200) {
-            var geodesyMl: any = response.text();
-            let json: string = this.jsonixService.geodesyMLToJson(geodesyMl);
-            console.log('handleXMLData - json: ', json);
-            return json;
-        } else {
-            let msg: string = 'Error with GET: ' + response.url;
-            throw new Error(msg);
-        }
-    }
 
     /**
      * Creates a new SiteLogService with the injected Http.
@@ -76,24 +65,6 @@ export class SiteLogService {
         });
     }
 
-    /**
-     * Returns one site log defined by the fourCharacterId.  Alternative method that retrieves GeodeesyML format
-     * from the backend service and returns an alternative JSON equivalent that is almost, but not quite the same
-     * as the JSON returned froom getSiteLogByFourCharacterId();
-     * @param {string} fourCharacterId - The Four Character Id of the site.
-     * @return {object[]} The Observable for the HTTP request in JSON format slightly different from that from
-     * getSiteLogByFourCharacterId().
-     */
-    private doGetSiteLogByFourCharacterIdUsingGeodesyML(fourCharacterId: string): Observable<any> {
-        console.log('getSiteLogByFourCharacterId(fourCharacterId: ', fourCharacterId);
-        return this.http.get(this.constantsService.getWebServiceURL()
-            + '/siteLogs/search/findByFourCharacterId?id=' + fourCharacterId + '&format=geodesyml')
-            .map((response: Response) => {
-                return this.handleXMLData(response);
-            })
-            .catch(HttpUtilsService.handleError);
-    }
-
     getSiteLogByFourCharacterIdUsingGeodesyMLWFS(fourCharacterId: string): Observable<any> {
         // console.log('getSiteLogByFourCharacterIdGeodesyMLWFS(fourCharacterId: ', fourCharacterId);
         let params: SelectSiteSearchType = {
@@ -108,15 +79,6 @@ export class SiteLogService {
                     obs.error('ERROR in getSiteLogByFourCharacterIdUsingGeodesyMLWFS: ', e);
                 });
             });
-    }
-
-    private handleData(response: Response) {
-        console.debug('site log service - from wfsService - handle data - response: ', response);
-        let data: any = response.text();//.json();
-        let status: number = response.status;
-        let statustext: string = response.statusText;
-        console.debug('SiteLogService call wfsQuery - status: ' + status + ' status text: ' + statustext + ' data: ', data);
-        return response; //data;
     }
 
     /**
@@ -184,5 +146,44 @@ export class SiteLogService {
         return this.http.post(this.constantsService.getWebServiceURL() + '/siteLogs/upload', geodesyMl)
             .map(HttpUtilsService.handleJsonData)
             .catch(HttpUtilsService.handleError);
+    }
+
+    private handleXMLData(response: Response): string {
+        if (response.status === 200) {
+            var geodesyMl: any = response.text();
+            let json: string = this.jsonixService.geodesyMLToJson(geodesyMl);
+            console.log('handleXMLData - json: ', json);
+            return json;
+        } else {
+            let msg: string = 'Error with GET: ' + response.url;
+            throw new Error(msg);
+        }
+    }
+
+    /**
+     * Returns one site log defined by the fourCharacterId.  Alternative method that retrieves GeodeesyML format
+     * from the backend service and returns an alternative JSON equivalent that is almost, but not quite the same
+     * as the JSON returned froom getSiteLogByFourCharacterId();
+     * @param {string} fourCharacterId - The Four Character Id of the site.
+     * @return {object[]} The Observable for the HTTP request in JSON format slightly different from that from
+     * getSiteLogByFourCharacterId().
+     */
+    private doGetSiteLogByFourCharacterIdUsingGeodesyML(fourCharacterId: string): Observable<any> {
+        console.log('getSiteLogByFourCharacterId(fourCharacterId: ', fourCharacterId);
+        return this.http.get(this.constantsService.getWebServiceURL()
+            + '/siteLogs/search/findByFourCharacterId?id=' + fourCharacterId + '&format=geodesyml')
+            .map((response: Response) => {
+                return this.handleXMLData(response);
+            })
+            .catch(HttpUtilsService.handleError);
+    }
+
+    private handleData(response: Response) {
+        console.debug('site log service - from wfsService - handle data - response: ', response);
+        let data: any = response.text();//.json();
+        let status: number = response.status;
+        let statustext: string = response.statusText;
+        console.debug('SiteLogService call wfsQuery - status: ' + status + ' status text: ' + statustext + ' data: ', data);
+        return response; //data;
     }
 }

--- a/src/client/app/shared/site-log/site-log.service.ts
+++ b/src/client/app/shared/site-log/site-log.service.ts
@@ -1,15 +1,15 @@
-import {Injectable} from '@angular/core';
-import {Http, Response} from '@angular/http';
-import {Observable} from 'rxjs/Rx';
+import { Injectable } from '@angular/core';
+import { Http, Response } from '@angular/http';
+import { Observable } from 'rxjs/Rx';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
-import {JsonixService} from '../jsonix/jsonix.service';
-import {WFSService, SelectSiteSearchType} from '../wfs/wfs.service';
-import {HttpUtilsService} from '../global/http-utils.service';
-import {ConstantsService} from '../global/constants.service';
-import {JsonViewModelService} from '../json-data-view-model/json-view-model.service';
-import {SiteLogViewModel} from '../json-data-view-model/view-model/site-log-view-model';
-import {SiteLogDataModel} from '../json-data-view-model/data-model/site-log-data-model';
+import { JsonixService } from '../jsonix/jsonix.service';
+import { WFSService, SelectSiteSearchType } from '../wfs/wfs.service';
+import { HttpUtilsService } from '../global/http-utils.service';
+import { ConstantsService } from '../global/constants.service';
+import { JsonViewModelService } from '../json-data-view-model/json-view-model.service';
+import { SiteLogViewModel } from '../json-data-view-model/view-model/site-log-view-model';
+import { SiteLogDataModel } from '../json-data-view-model/data-model/site-log-data-model';
 
 /**
  * This class provides the service with methods to retrieve CORS Setup info from DB.

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -47,6 +47,28 @@ export class ToolbarComponent implements OnInit {
     return true;
   }
 
+  /**
+   * Component method to request the Service Worker clears it's cache.
+   */
+  clearCache = (): void => {
+    this.serviceWorkerService.clearCache().then((data: string) => {
+      console.debug('toolbar.component clearCacheObservable() success: ', data);
+      // Force a reloading of the cache
+      self.location.reload();
+    }, (error: Error) => {
+      throw new Error('Error in clearCacheObservable: ' + error.message);
+    });
+  }
+
+  updateCacheList = (): void => {
+    this.serviceWorkerService.getCacheList().then((data: string[]) => {
+      this.cacheItems.length = 0;
+      this.cacheItems = data;
+    }).catch((error: any) => {
+      console.error('Caught error in updateCacheList:', error);
+    });
+  }
+
   private setupSubscriptions() {
     this.setupServiceWorkerSubscription();
     this.setupRouterSubscription();
@@ -73,27 +95,5 @@ export class ToolbarComponent implements OnInit {
             this.siteId = obj.id;
           });
         });
-  }
-
-  /**
-   * Component method to request the Service Worker clears it's cache.
-   */
-  clearCache = (): void => {
-    this.serviceWorkerService.clearCache().then((data: string) => {
-      console.debug('toolbar.component clearCacheObservable() success: ', data);
-      // Force a reloading of the cache
-      self.location.reload();
-    }, (error: Error) => {
-      throw new Error('Error in clearCacheObservable: ' + error.message);
-    });
-  }
-
-  updateCacheList = (): void => {
-    this.serviceWorkerService.getCacheList().then((data: string[]) => {
-      this.cacheItems.length = 0;
-      this.cacheItems = data;
-    }).catch((error: any) => {
-      console.error('Caught error in updateCacheList:', error);
-    });
   }
 }

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -18,7 +18,7 @@ export class ToolbarComponent implements OnInit {
   @Output() onClose: EventEmitter<boolean> = new EventEmitter<boolean>();
   private serviceWorkerSubscription: Subscription;
   private cacheItems: Array<string> = [];
-  private siteId: string
+  private siteId: string;
 
   constructor(
     private serviceWorkerService: ServiceWorkerService,
@@ -86,7 +86,7 @@ export class ToolbarComponent implements OnInit {
     }, (error: Error) => {
       throw new Error('Error in clearCacheObservable: ' + error.message);
     });
-  };
+  }
 
   updateCacheList = (): void => {
     this.serviceWorkerService.getCacheList().then((data: string[]) => {
@@ -95,5 +95,5 @@ export class ToolbarComponent implements OnInit {
     }).catch((error: any) => {
       console.error('Caught error in updateCacheList:', error);
     });
-  };
+  }
 }

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -13,12 +13,12 @@ import { NavigationEnd, Router, ActivatedRoute, Params } from '@angular/router';
   styleUrls: ['toolbar.component.css']
 })
 export class ToolbarComponent implements OnInit {
+  public siteId: string;
   @Output() onSave: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() onRevert: EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() onClose: EventEmitter<boolean> = new EventEmitter<boolean>();
   private serviceWorkerSubscription: Subscription;
   private cacheItems: Array<string> = [];
-  private siteId: string;
 
   constructor(
     private serviceWorkerService: ServiceWorkerService,

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -13,6 +13,12 @@ import { SiteLogViewModel } from '../shared/json-data-view-model/view-model/site
   templateUrl: 'site-info.component.html'
 })
 export class SiteInfoComponent implements OnInit, OnDestroy {
+  public miscUtils: any = MiscUtils;
+  public siteContactName: string = ConstantsService.SITE_CONTACT;
+  public siteMetadataCustodianName: string = ConstantsService.SITE_METADATA_CUSTODIAN;
+  public siteDataCenterName: string = ConstantsService.SITE_DATA_CENTER;
+  public siteDataSourceName: string = ConstantsService.SITE_DATA_SOURCE;
+
   private siteId: string;
   private isLoading: boolean = false;
   private siteLogOrigin: any = {};
@@ -26,13 +32,6 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
   private errorMessage: string;
   private siteInfoTab: any = null;
   private submitted: boolean = false;
-  public miscUtils: any = MiscUtils;
-
-  public siteContactName: string = ConstantsService.SITE_CONTACT;
-  public siteMetadataCustodianName: string = ConstantsService.SITE_METADATA_CUSTODIAN;
-  public siteDataCenterName: string = ConstantsService.SITE_DATA_CENTER;
-  public siteDataSourceName: string = ConstantsService.SITE_DATA_SOURCE;
-
   private status: any = {
     oneAtATime: false,
     isSiteInfoGroupOpen: true,

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -18,21 +18,17 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
   public siteMetadataCustodianName: string = ConstantsService.SITE_METADATA_CUSTODIAN;
   public siteDataCenterName: string = ConstantsService.SITE_DATA_CENTER;
   public siteDataSourceName: string = ConstantsService.SITE_DATA_SOURCE;
-
-  private siteId: string;
-  private isLoading: boolean = false;
-  private siteLogOrigin: any = {};
-  private siteLogModel: any = {};
-  private siteIdentification: any = null;
-  private siteLocation: any = {};
-  private siteContacts: Array<any> = [];
-  private siteMetadataCustodian: any = {};
-  private siteDataCenters: Array<any> = [];
-  private siteDataSource: any = {};
-  private errorMessage: string;
-  private siteInfoTab: any = null;
-  private submitted: boolean = false;
-  private status: any = {
+  public siteId: string;
+  public isLoading: boolean = false;
+  public siteLogOrigin: any = {};
+  public siteLogModel: any = {};
+  public siteIdentification: any = null;
+  public siteLocation: any = {};
+  public siteContacts: Array<any> = [];
+  public siteMetadataCustodian: any = {};
+  public siteDataCenters: Array<any> = [];
+  public siteDataSource: any = {};
+  public status: any = {
     oneAtATime: false,
     isSiteInfoGroupOpen: true,
     isSiteMediaOpen: false,
@@ -42,6 +38,10 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     hasNewSiteDataCenter: false,
     hasNewSiteDataSource: false,
   };
+
+  private errorMessage: string;
+  private siteInfoTab: any = null;
+  private submitted: boolean = false;
 
   /**
    * Creates an instance of the SiteInfoComponent with the injected Router/ActivatedRoute/CorsSite Services.

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 import { ConstantsService, DialogService, MiscUtils,
          SiteLogService, JsonDiffService, JsonCheckService } from '../shared/index';
-import {SiteLogViewModel} from '../shared/json-data-view-model/view-model/site-log-view-model';
+import { SiteLogViewModel } from '../shared/json-data-view-model/view-model/site-log-view-model';
 
 /**
  * This class represents the SiteInfoComponent for viewing and editing the details of site/receiver/antenna.

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {SurveyedLocalTieViewModel} from './surveyed-local-tie-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { SurveyedLocalTieViewModel } from './surveyed-local-tie-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class SurveyedLocalTieViewModel extends AbstractViewModel {
 

--- a/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {SurveyedLocalTieViewModel} from './surveyed-local-tie-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { SurveyedLocalTieViewModel } from './surveyed-local-tie-view-model';
 
 /**.
  * This class represents a group of Surveyed Local Ties.

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {TemperatureSensorViewModel} from './temperature-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { TemperatureSensorViewModel } from './temperature-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
@@ -1,5 +1,5 @@
-import {TemperatureSensorViewModel} from './temperature-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { TemperatureSensorViewModel } from './temperature-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 export function main() {
   let temperatureSensorsViewModel: TemperatureSensorViewModel;
 

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class TemperatureSensorViewModel extends AbstractViewModel {
   /**

--- a/src/client/app/temperature-sensor/temperature-sensors-group.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensors-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {TemperatureSensorViewModel} from './temperature-sensor-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { TemperatureSensorViewModel } from './temperature-sensor-view-model';
 
 /**
  * This class represents a group of Temperature Sensors.

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -1,8 +1,8 @@
-import {Component, Input, Output, EventEmitter} from '@angular/core';
-import {AbstractItem} from '../shared/abstract-groups-items/abstract-item';
-import {GeodesyEvent} from '../shared/events-messages/Event';
-import {WaterVaporSensorViewModel} from './water-vapor-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { GeodesyEvent } from '../shared/events-messages/Event';
+import { WaterVaporSensorViewModel } from './water-vapor-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 import { DialogService } from '../shared/index';
 
 /**

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
@@ -1,5 +1,5 @@
-import {WaterVaporSensorViewModel} from './water-vapor-sensor-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { WaterVaporSensorViewModel } from './water-vapor-sensor-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 export function main() {
   let waterVaporSensorsViewModel: WaterVaporSensorViewModel;
 

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
@@ -1,5 +1,5 @@
-import {AbstractViewModel} from '../shared/json-data-view-model/view-model/abstract-view-model';
-import {MiscUtils} from '../shared/global/misc-utils';
+import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
+import { MiscUtils } from '../shared/global/misc-utils';
 
 export class WaterVaporSensorViewModel extends AbstractViewModel {
   /**

--- a/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.ts
@@ -1,7 +1,7 @@
-import {Component, Input} from '@angular/core';
-import {MiscUtils} from '../shared/index';
-import {AbstractGroup} from '../shared/abstract-groups-items/abstract-group';
-import {WaterVaporSensorViewModel} from './water-vapor-sensor-view-model';
+import { Component, Input } from '@angular/core';
+import { MiscUtils } from '../shared/index';
+import { AbstractGroup } from '../shared/abstract-groups-items/abstract-group';
+import { WaterVaporSensorViewModel } from './water-vapor-sensor-view-model';
 
 /**
  * This class represents a group of WaterVapor Sensors.

--- a/tools/env/docker.ts
+++ b/tools/env/docker.ts
@@ -1,4 +1,4 @@
-import {EnvConfig} from './env-config.interface';
+import { EnvConfig } from './env-config.interface';
 
 const DockerConfig: EnvConfig = {
   ENV: 'LOCAL',

--- a/tools/env/local.ts
+++ b/tools/env/local.ts
@@ -1,4 +1,4 @@
-import {EnvConfig} from './env-config.interface';
+import { EnvConfig } from './env-config.interface';
 
 const LocalConfig: EnvConfig = {
   ENV: 'LOCAL',

--- a/tools/env/test.ts
+++ b/tools/env/test.ts
@@ -1,4 +1,4 @@
-import {EnvConfig} from './env-config.interface';
+import { EnvConfig } from './env-config.interface';
 
 const TestConfig: EnvConfig = {
   ENV: 'TEST',

--- a/tools/env/uat.ts
+++ b/tools/env/uat.ts
@@ -1,4 +1,4 @@
-import {EnvConfig} from './env-config.interface';
+import { EnvConfig } from './env-config.interface';
 
 const UatConfig: EnvConfig = {
   ENV: 'UAT',

--- a/tools/tasks/project/copy.js.local.prod.ts
+++ b/tools/tasks/project/copy.js.local.prod.ts
@@ -6,13 +6,13 @@ import { argv } from 'yargs';
 import Config from '../../config';
 
 /**
- * This sample task should come late in the build chain after the .ts are transpiled into .js under dist/tmp.  
- * It copies from there all JavaScript files under jslocal to the appropiate `dist/dev|prod|test/js` directory, 
+ * This sample task should come late in the build chain after the .ts are transpiled into .js under dist/tmp.
+ * It copies from there all JavaScript files under jslocal to the appropiate `dist/dev|prod|test/js` directory,
  * where other .js artifacts are built.
- * 
+ *
  * 1. .js files are copied to the angular-2 built js/ directory.
  * 2. Service Worker .js files (ones that start with 'service-worker') are copied to the root since that
- * becomes the scope of the service-worker (putting the file(s) into 'js/' would limit its scope to only 
+ * becomes the scope of the service-worker (putting the file(s) into 'js/' would limit its scope to only
  * that directory).
  */
 export = () => {


### PR DESCRIPTION
Five types of warning messages have been removed, and only one remains unresolved as it is a known issue in codelyzer (https://github.com/mgechev/codelyzer/issues/191) that has been recently fixed in the latest release 3.0.0-beta.0. An update of tslint codelyzer will remove these warning messages.

 Examples of warning messages unresolved: 
src/client/app/frequency-standard/frequency-standard-group.component.html[4, 19]: The property "**isGroupOpen**" that you're trying to access does not exist in the class declaration.
src/client/app/frequency-standard/frequency-standard-group.component.html[13, 26]: The property "**hasGroupANewItem**" that you're trying to access does not exist in the class declaration.
src/client/app/frequency-standard/frequency-standard-item.component.html[4, 19]: The property "**isOpen**" that you're trying to access does not exist in the class declaration.
src/client/app/frequency-standard/frequency-standard-item.component.html[18, 23]: The method "**getRemoveOrDeletedText**" that you're trying to access does not exist in the class declaration.
... ...