### PR TITLE
GEOD-379 - Fix dirty and valid so only parents view changes

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-group.component.html
+++ b/src/client/app/frequency-standard/frequency-standard-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
     <span class="panel-title cursor-ptr"
           (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/frequency-standard/frequency-standard-item.component.html
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2" id="frequencyStandard_{{index}}">
+<div [formGroup]="itemGroup" class="panel panel-level-2" id="frequencyStandard_{{index}}" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
     <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
       <i class="glyphicon"

--- a/src/client/app/gnss-antenna/gnss-antenna-group.component.html
+++ b/src/client/app/gnss-antenna/gnss-antenna-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
             <span class="panel-title cursor-ptr"
                   (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.html
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2" id="antenna_{{index}}">
+<div [formGroup]="itemGroup" class="panel panel-level-2" id="antenna_{{index}}" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
       <i class="glyphicon"

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.html
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
             <i class="glyphicon"

--- a/src/client/app/gnss-receiver/gnss-receivers-group.component.html
+++ b/src/client/app/gnss-receiver/gnss-receivers-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.html
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
             <i class="glyphicon"

--- a/src/client/app/humidity-sensor/humidity-sensors-group.component.html
+++ b/src/client/app/humidity-sensor/humidity-sensors-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.html
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr"
               (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">

--- a/src/client/app/local-episodic-effect/local-episodic-effects-group.component.html
+++ b/src/client/app/local-episodic-effect/local-episodic-effects-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.html
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr"
               (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">

--- a/src/client/app/pressure-sensor/pressure-sensors-group.component.html
+++ b/src/client/app/pressure-sensor/pressure-sensors-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/responsible-party/responsible-party-group.component.html
+++ b/src/client/app/responsible-party/responsible-party-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-2">
+<div [formGroup]="siteInfoForm" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/responsible-party/responsible-party-item.component.html
+++ b/src/client/app/responsible-party/responsible-party-item.component.html
@@ -1,5 +1,5 @@
 <!-- Input: temperatureSensor (single) -->
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
             <i class="glyphicon" [ngClass]="{'glyphicon-minus-sign': isOpen, 'glyphicon-plus-sign': !isOpen}"> </i>

--- a/src/client/app/shared/abstract-groups-items/abstract-group.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.ts
@@ -275,6 +275,15 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
         this.itemProperties.splice(newIndex, 1);
     }
 
+
+    public isFormDirty(): boolean {
+        return this.groupArrayForm ? this.groupArrayForm.dirty : false;
+    }
+
+    public isFormInvalid(): boolean {
+        return this.groupArrayForm ? ! this.groupArrayForm.valid : false;
+    }
+
     /* ************** Private Methods ************** */
 
     private addNewItem(): void {

--- a/src/client/app/shared/abstract-groups-items/abstract-item.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.ts
@@ -140,6 +140,14 @@ export abstract class AbstractItem implements OnInit, OnChanges {
         return this.isNew ? 'Cancel' : 'Delete';
     }
 
+    public isFormDirty(): boolean {
+        return this.itemGroup ? this.itemGroup.dirty : false;
+    }
+
+    public isFormInvalid(): boolean {
+        return this.itemGroup ? ! this.itemGroup.valid : false;
+    }
+
     /**
      * Add the itemGroup (the item) to the array (groupArray).
      * @param itemGroup to add

--- a/src/client/app/shared/abstract-groups-items/abstract-item.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.ts
@@ -126,6 +126,7 @@ export abstract class AbstractItem implements OnInit, OnChanges {
             (deleteReason : string) => {
                // ok callback
                this.deleteItem(index, deleteReason);
+                this.itemGroup.markAsDirty();
             },
             () => {
               // cancel callback
@@ -141,7 +142,7 @@ export abstract class AbstractItem implements OnInit, OnChanges {
     }
 
     public isFormDirty(): boolean {
-        return this.itemGroup ? this.itemGroup.dirty : false;
+        return this.itemGroup ? (this.itemGroup.dirty || this.isNew) : false;
     }
 
     public isFormInvalid(): boolean {

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -47,8 +47,8 @@ export class ToolbarComponent implements OnInit {
   }
 
   revert() {
-    // this.onRevert.emit( this.siteId !== null );
-    javascript:history.go(0);
+    this.onRevert.emit( this.siteId !== null );
+    // javascript:history.go(0);
   }
 
   close() {

--- a/src/client/app/site-info/site-identification.component.html
+++ b/src/client/app/site-info/site-identification.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteIdentificationForm" class="panel panel-level-2">
+<div [formGroup]="siteIdentificationForm" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="status.isSiteIdentificationGroupOpen = miscUtils.scrollIntoView($event, status.isSiteIdentificationGroupOpen)">
               <i class="glyphicon"

--- a/src/client/app/site-info/site-identification.component.ts
+++ b/src/client/app/site-info/site-identification.component.ts
@@ -11,7 +11,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
     templateUrl: 'site-identification.component.html'
 })
 export class SiteIdentificationComponent implements OnInit {
-    @Input('siteInfoForm') siteInfoForm: FormGroup;
+    @Input('siteInformationForm') siteInformationForm: FormGroup;
 
     status: any = {
         isSiteIdentificationGroupOpen: false
@@ -91,7 +91,7 @@ export class SiteIdentificationComponent implements OnInit {
             distanceActivity: [''],//, [Validators.maxLength(100)]],
             notes: [''],//, [Validators.maxLength(2000)]],
     });
-        this.siteInfoForm.addControl('siteIdentification', this.siteIdentificationForm);
+        this.siteInformationForm.addControl('siteIdentification', this.siteIdentificationForm);
     }
 
     private patchForm() {

--- a/src/client/app/site-info/site-identification.component.ts
+++ b/src/client/app/site-info/site-identification.component.ts
@@ -60,6 +60,14 @@ export class SiteIdentificationComponent implements OnInit {
         // patchForm is called from the setter in this form
     }
 
+    public isFormDirty(): boolean {
+        return this.siteIdentificationForm ? this.siteIdentificationForm.dirty : false;
+    }
+
+    public isFormInvalid(): boolean {
+        return this.siteIdentificationForm ? ! this.siteIdentificationForm.valid : false;
+    }
+
     private setupForm() {
         this.siteIdentificationForm = this.formBuilder.group({
             siteName: [''],//, [Validators.minLength(4), Validators.maxLength(100)]],

--- a/src/client/app/site-info/site-info.component.html
+++ b/src/client/app/site-info/site-info.component.html
@@ -2,7 +2,7 @@
     <div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12 pad-sm">
         <form [formGroup]="siteInfoForm" novalidate class="form-horizontal">
             <div class="panel-group">
-                <div [formGroup]="siteInfoForm" class="panel panel-level-1">
+                <div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
                     <div class="panel-heading">
                         <span class="panel-title cursor-ptr"
                               (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/site-info/site-info.component.html
+++ b/src/client/app/site-info/site-info.component.html
@@ -2,7 +2,7 @@
     <div class="col-md-12 col-sm-12 col-xs-12 col-xxs-12 pad-sm">
         <form [formGroup]="siteInfoForm" novalidate class="form-horizontal">
             <div class="panel-group">
-                <div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
+                <div [formGroup]="siteInformationForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isSiteInformationFormDirty(), 'gnss-invalid': isSiteInformationFormInvalid()}">
                     <div class="panel-heading">
                         <span class="panel-title cursor-ptr"
                               (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">
@@ -12,23 +12,23 @@
                         </span>
                     </div>
                     <div class="panel-body">
-                        <site-identification [siteInfoForm]="siteInfoForm"
+                        <site-identification [siteInformationForm]="siteInformationForm"
                                              [siteLogModel]="siteLogModel"
                                              [originalSiteLogModel]="siteLogOrigin">
                         </site-identification>
 
-                        <site-location [siteInfoForm]="siteInfoForm"
+                        <site-location [siteInformationForm]="siteInformationForm"
                                        [siteLogModel]="siteLogModel"
                                        [originalSiteLogModel]="siteLogOrigin">
                         </site-location>
 
-                        <gnss-responsible-party-group [siteInfoForm]="siteInfoForm"
+                        <gnss-responsible-party-group [siteInfoForm]="siteInformationForm"
                                                       [partyName]="responsiblePartyType.siteContact"
                                                       [siteLogModel]="siteLogModel"
                                                       [originalSiteLogModel]="siteLogOrigin">
                         </gnss-responsible-party-group>
 
-                        <gnss-responsible-party-group [siteInfoForm]="siteInfoForm"
+                        <gnss-responsible-party-group [siteInfoForm]="siteInformationForm"
                                                       [partyName]="responsiblePartyType.siteMetadataCustodian"
                                                       [siteLogModel]="siteLogModel"
                                                       [originalSiteLogModel]="siteLogOrigin">
@@ -39,7 +39,7 @@
                         <!--[siteLogModel]="siteLogModel"-->
                         <!--[originalSiteLogModel]="siteLogOrigin"></gnss-responsible-party-group>-->
 
-                        <gnss-responsible-party-group [siteInfoForm]="siteInfoForm"
+                        <gnss-responsible-party-group [siteInfoForm]="siteInformationForm"
                                                       [partyName]="responsiblePartyType.siteDataSource"
                                                       [siteLogModel]="siteLogModel"
                                                       [originalSiteLogModel]="siteLogOrigin">

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -34,6 +34,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     // public siteDataCenterName: string = ConstantsService.SITE_DATA_CENTER;
     // public siteDataSourceName: string = ConstantsService.SITE_DATA_SOURCE;
     public siteInfoForm: FormGroup;                 // model driven forms
+    public siteInformationForm: FormGroup;                 // model driven forms
     public hasEditRole: boolean = false;
     // public formIsDirty: boolean = false;    // Necessary as need to compose dirty of template and model forms
 
@@ -282,9 +283,18 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
         return this.siteInfoForm ? ! this.siteInfoForm.valid : false;
     }
 
+    public isSiteInformationFormDirty(): boolean {
+        return this.siteInformationForm ? this.siteInformationForm.dirty : false;
+    }
+
+    public isSiteInformationFormInvalid(): boolean {
+        return this.siteInformationForm ? ! this.siteInformationForm.valid : false;
+    }
+
     private setupForm() {
-        this.siteInfoForm = this.formBuilder.group({
-        });
+        this.siteInformationForm = this.formBuilder.group({});
+        this.siteInfoForm = this.formBuilder.group({});
+        this.siteInfoForm.addControl('siteInformation', this.siteInformationForm);
     }
 
     private setupAuthSubscription(): Subscription {

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -274,6 +274,14 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     this.siteLogOrigin = MiscUtils.cloneJsonObj(this.siteLogModel);
   }
 
+    public isFormDirty(): boolean {
+        return this.siteInfoForm ? this.siteInfoForm.dirty : false;
+    }
+
+    public isFormInvalid(): boolean {
+        return this.siteInfoForm ? ! this.siteInfoForm.valid : false;
+    }
+
     private setupForm() {
         this.siteInfoForm = this.formBuilder.group({
         });

--- a/src/client/app/site-info/site-location.component.html
+++ b/src/client/app/site-info/site-location.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteLocationForm" class="panel panel-level-2">
+<div [formGroup]="siteLocationForm" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="status.isSiteLocationGroupOpen = miscUtils.scrollIntoView($event, status.isSiteLocationGroupOpen)">
               <i class="glyphicon"

--- a/src/client/app/site-info/site-location.component.ts
+++ b/src/client/app/site-info/site-location.component.ts
@@ -10,7 +10,7 @@ import { MiscUtils } from '../shared/global/misc-utils';
     templateUrl: 'site-location.component.html'
 })
 export class SiteLocationComponent implements OnInit, OnDestroy {
-    @Input('siteInfoForm') siteInfoForm: FormGroup;
+    @Input('siteInformationForm') siteInformationForm: FormGroup;
 
     status: any = {
         isSiteLocationGroupOpen: false
@@ -69,7 +69,7 @@ export class SiteLocationComponent implements OnInit, OnDestroy {
             tectonicPlate: ['', [Validators.maxLength(100)]],
             notes: ['', [Validators.maxLength(2000)]],
         });
-        this.siteInfoForm.addControl('siteLocation', this.siteLocationForm);
+        this.siteInformationForm.addControl('siteLocation', this.siteLocationForm);
     }
 
     private patchForm() {

--- a/src/client/app/site-info/site-location.component.ts
+++ b/src/client/app/site-info/site-location.component.ts
@@ -49,6 +49,14 @@ export class SiteLocationComponent implements OnInit, OnDestroy {
 
     }
 
+    public isFormDirty(): boolean {
+        return this.siteLocationForm ? this.siteLocationForm.dirty : false;
+    }
+
+    public isFormInvalid(): boolean {
+        return this.siteLocationForm ? ! this.siteLocationForm.valid : false;
+    }
+
     private setupForm() {
         this.siteLocationForm = this.formBuilder.group({
             city: ['', [Validators.maxLength(100)]],

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.html
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
             <i class="glyphicon"

--- a/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.html
+++ b/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.html
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr" (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">
             <i class="glyphicon"

--- a/src/client/app/temperature-sensor/temperature-sensors-group.component.html
+++ b/src/client/app/temperature-sensor/temperature-sensors-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.html
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="itemGroup" class="panel panel-level-2">
+<div [formGroup]="itemGroup" class="panel panel-level-2" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr"
               (click)="isOpen = miscUtils.scrollIntoView($event, isOpen)">

--- a/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.html
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="siteInfoForm" class="panel panel-level-1">
+<div [formGroup]="siteInfoForm" class="panel panel-level-1" [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
   <div class="panel-heading">
       <span class="panel-title cursor-ptr"
             (click)="isGroupOpen = miscUtils.scrollIntoView($event, isGroupOpen)">

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -427,28 +427,28 @@ ul {
   background-color: #008369;
   padding: 3px 5px;
 }
-.panel-level-1.ng-dirty {
+.panel-level-1.gnss-dirty {
   border-color: #006a55 !important;
 }
-.panel-level-1.ng-dirty > .panel-heading {
+.panel-level-1.gnss-dirty > .panel-heading {
   background-color: #008369 !important;
 }
-.panel-level-2.ng-dirty {
+.panel-level-2.gnss-dirty {
   border-color: #afeec4 !important;
 }
-.panel-level-2.ng-dirty > .panel-heading {
+.panel-level-2.gnss-dirty > .panel-heading {
   background-color: #d9f7e3 !important;
 }
-.panel-level-1.ng-invalid {
+.panel-level-1.gnss-invalid {
     border-color: #a33f1f !important;
 }
-.panel-level-1.ng-invalid > .panel-heading {
+.panel-level-1.gnss-invalid > .panel-heading {
   background-color: #a33f1f !important;
 }
-.panel-level-2.ng-invalid {
+.panel-level-2.gnss-invalid {
   border-color: #ffd497 !important;
 }
-.panel-level-2.ng-invalid > .panel-heading {
+.panel-level-2.gnss-invalid > .panel-heading {
   background-color: #ffe9ca !important;
 }
 input.ng-dirty.ng-valid,


### PR DESCRIPTION
* ng-dirty is applied to modified form fields, its form and any parent forms.
* There was a bug where it seems to also apply to the forms with the same form variable name.  So all sibling forms in our case.
* Fixed by working around and not using 'ng-dirty' and 'ng-invalid' but our own 'gnss-dirty' and 'gnss-invalid'