### PR TITLE
GEOD-379 - Due to modified SiteInfo move obj into place

### DIFF
--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -180,6 +180,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
       console.log(' siteLog before form merge: ', this.siteLogModel);
       console.log(' formValue before merge and reverse: ', formValue);
       let formValueClone: any =_.cloneDeep(formValue);
+      this.moveSiteInformationUp(formValueClone);
 
       /* Get the arrays in the form in the same order as the SiteLogModel */
       this.sortArrays(formValueClone);
@@ -375,6 +376,28 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
                     formValue[item].sort(comparator);//this.compare);
                 }
             }
+        }
+    }
+
+    /**
+     * Due to how we artifically nest SiteLocation and SiteIdentification under a SiteIdentificationForm, this data is not in the
+     * same location as the SiteLogModel.  This method moves it up a level.
+     *
+     * @param formValue
+     */
+    private moveSiteInformationUp(formValue: any) {
+        this.moveSiteInformationUpSpecifically(formValue, 'siteIdentification');
+        this.moveSiteInformationUpSpecifically(formValue, 'siteLocation');
+        this.moveSiteInformationUpSpecifically(formValue, 'siteContact');
+        this.moveSiteInformationUpSpecifically(formValue, 'siteMetadataCustodian');
+        this.moveSiteInformationUpSpecifically(formValue, 'siteDataSource');
+        delete formValue.siteInformation;
+    }
+
+    private moveSiteInformationUpSpecifically(formValue: any, subObject: string) {
+        if (formValue.siteInformation[subObject]) {
+            formValue[subObject] = formValue.siteInformation[subObject];
+            delete formValue.siteInformation[subObject];
         }
     }
 }


### PR DESCRIPTION
* For the recent FixDirty commit, the SiteLocation, SiteIdentification
and all the SiteContacts were moved under an extra form so that we
could see when they are dirty (I termed this the 'artificial form'
since it isn't in the data, yet the data structure gets represented
by it).
* And ofcourse these components are in the root of the
SiteLogModel.  This change moves those components back to the root.
* Necessary for the diff and save