### PR TITLE
Reactive model g379 bug form holding empty values

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-group.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-group.component.ts
@@ -54,8 +54,4 @@ export class FrequencyStandardGroupComponent extends AbstractGroup<FrequencyStan
     newItemViewModel(blank?: boolean): FrequencyStandardViewModel {
         return new FrequencyStandardViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return FrequencyStandardItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { FrequencyStandardViewModel } from './frequency-standard-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,20 +35,26 @@ export class FrequencyStandardItemComponent extends AbstractItem implements OnIn
         return this.frequencyStandard;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            standardType: [''],//, [Validators.minLength(4)]],
-            inputFrequency: [''],//, [Validators.maxLength(100)]],
-            startDate: [''],//, [Validators.required]],
-            endDate: [''],  //  requiredIfNotCurrent="true"
-            notes: [''],//, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {standardType: new FormControl([''])},//, [Validators.minLength(4)]],
+            {inputFrequency: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl([''])},  //  requiredIfNotCurrent="true"
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -45,15 +45,15 @@ export class FrequencyStandardItemComponent extends AbstractItem implements OnIn
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {standardType: new FormControl([''])},//, [Validators.minLength(4)]],
-            {inputFrequency: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl([''])},  //  requiredIfNotCurrent="true"
+            {standardType: new FormControl('')},//, [Validators.minLength(4)]],
+            {inputFrequency: new FormControl('')},//, [Validators.maxLength(100)]],
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  //  requiredIfNotCurrent="true"
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/gnss-antenna/gnss-antenna-group.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-group.component.ts
@@ -52,8 +52,4 @@ export class GnssAntennaGroupComponent extends AbstractGroup<GnssAntennaViewMode
     newItemViewModel(blank?: boolean): GnssAntennaViewModel {
         return new GnssAntennaViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return GnssAntennaItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, Injector } from '@angular/core';
 import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
 import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { GnssAntennaViewModel } from './gnss-antenna-view-model';
@@ -19,7 +19,7 @@ export class GnssAntennaItemComponent extends AbstractItem implements OnInit {
      */
     @Input() antenna: GnssAntennaViewModel;
 
-    constructor(protected dialogService: DialogService, private formBuilder: FormBuilder) {
+    constructor(protected dialogService: DialogService) {
         super(dialogService);
     }
 
@@ -45,24 +45,24 @@ export class GnssAntennaItemComponent extends AbstractItem implements OnInit {
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {antennaType: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {serialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dateInstalled: new FormControl([''])},//, [Validators.required, dateTimeFormatValidator]],
+            {antennaType: new FormControl('')},//, [Validators.maxLength(100)]],
+            {serialNumber: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dateInstalled: new FormControl('')},//, [Validators.required, dateTimeFormatValidator]],
             {dateRemoved: new FormControl('')},    // requiredIfNotCurrent="true"
-            {antennaReferencePoint: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {markerArpEastEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {markerArpUpEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {markerArpNorthEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {alignmentFromTrueNorth: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {antennaRadomeType: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {radomeSerialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {antennaCableType: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {antennaCableLength: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {antennaReferencePoint: new FormControl('')},//, [Validators.maxLength(100)]],
+            {markerArpEastEcc: new FormControl('')},//, [Validators.maxLength(100)]],
+            {markerArpUpEcc: new FormControl('')},//, [Validators.maxLength(100)]],
+            {markerArpNorthEcc: new FormControl('')},//, [Validators.maxLength(100)]],
+            {alignmentFromTrueNorth: new FormControl('')},//, [Validators.maxLength(100)]],
+            {antennaRadomeType: new FormControl('')},//, [Validators.maxLength(100)]],
+            {radomeSerialNumber: new FormControl('')},//, [Validators.maxLength(100)]],
+            {antennaCableType: new FormControl('')},//, [Validators.maxLength(100)]],
+            {antennaCableLength: new FormControl('')},//, [Validators.maxLength(100)]],
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 }

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { GnssAntennaViewModel } from './gnss-antenna-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,29 +35,34 @@ export class GnssAntennaItemComponent extends AbstractItem implements OnInit {
         return this.antenna;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            antennaType: [''],//, [Validators.maxLength(100)]],
-            serialNumber: [''],//, [Validators.maxLength(100)]],
-            dateInstalled: [''],//, [Validators.required, dateTimeFormatValidator]],
-            dateRemoved: '',    // requiredIfNotCurrent="true"
-            antennaReferencePoint: [''],//, [Validators.maxLength(100)]],
-            markerArpEastEcc: [''],//, [Validators.maxLength(100)]],
-            markerArpUpEcc: [''],//, [Validators.maxLength(100)]],
-            markerArpNorthEcc: [''],//, [Validators.maxLength(100)]],
-            alignmentFromTrueNorth: [''],//, [Validators.maxLength(100)]],
-            antennaRadomeType: [''],//, [Validators.maxLength(100)]],
-            radomeSerialNumber: [''],//, [Validators.maxLength(100)]],
-            antennaCableType: [''],//, [Validators.maxLength(100)]],
-            antennaCableLength: [''],//, [Validators.maxLength(100)]],
-            notes: [''],//, [Validators.maxLength(20)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {antennaType: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {serialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dateInstalled: new FormControl([''])},//, [Validators.required, dateTimeFormatValidator]],
+            {dateRemoved: new FormControl('')},    // requiredIfNotCurrent="true"
+            {antennaReferencePoint: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {markerArpEastEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {markerArpUpEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {markerArpNorthEcc: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {alignmentFromTrueNorth: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {antennaRadomeType: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {radomeSerialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {antennaCableType: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {antennaCableLength: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
 }

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, Validators, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { GnssReceiverViewModel } from './gnss-receiver-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -23,26 +23,30 @@ export class GnssReceiverItemComponent extends AbstractItem implements OnInit {
         super(dialogService);
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            receiverType: [''],//, [Validators.maxLength(100)]],
-            manufacturerSerialNumber: [''],//, [Validators.maxLength(100)]],
-            dateInstalled: [''],//, [Validators.required, dateTimeFormatValidator]],
-            dateRemoved: [''],//, [requiredIfNotCurrent="true" , dateTimeFormatValidator]],
-            firmwareVersion: [''],//, [Validators.maxLength(100)]],
-            satelliteSystem: [''],//, [Validators.maxLength(100)]],
-            elevationCutoffSetting: [''],//, [Validators.maxLength(100)]],
-            temperatureStabilization: [''],//, [Validators.required]],//, [Validators.maxLength(100)]],
-            notes: ['', [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: [''],
-            dateInserted: [''],
-            deletedReason: [''],
-        });
-        // console.debug('GnssReceiverItemComponent - setup (push) new form - index: ', this.getIndex());
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {receiverType: new FormControl([''])}, //, [Validators.maxLength(100)]],
+            {manufacturerSerialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dateInstalled: new FormControl([''])},//, [Validators.required, dateTimeFormatValidator]],
+            {dateRemoved: new FormControl([''])},//, [requiredIfNotCurrent="true" , dateTimeFormatValidator]],
+            {firmwareVersion: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {satelliteSystem: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {elevationCutoffSetting: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {temperatureStabilization: new FormControl([''])}, //, [Validators.required]],//, [Validators.maxLength(100)]],
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
 
     ngOnInit() {

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -33,19 +33,19 @@ export class GnssReceiverItemComponent extends AbstractItem implements OnInit {
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {receiverType: new FormControl([''])}, //, [Validators.maxLength(100)]],
-            {manufacturerSerialNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dateInstalled: new FormControl([''])},//, [Validators.required, dateTimeFormatValidator]],
-            {dateRemoved: new FormControl([''])},//, [requiredIfNotCurrent="true" , dateTimeFormatValidator]],
-            {firmwareVersion: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {satelliteSystem: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {elevationCutoffSetting: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {temperatureStabilization: new FormControl([''])}, //, [Validators.required]],//, [Validators.maxLength(100)]],
+            {receiverType: new FormControl('')}, //, [Validators.maxLength(100)]],
+            {manufacturerSerialNumber: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dateInstalled: new FormControl('')},//, [Validators.required, dateTimeFormatValidator]],
+            {dateRemoved: new FormControl('')},//, [requiredIfNotCurrent="true" , dateTimeFormatValidator]],
+            {firmwareVersion: new FormControl('')},//, [Validators.maxLength(100)]],
+            {satelliteSystem: new FormControl('')},//, [Validators.maxLength(100)]],
+            {elevationCutoffSetting: new FormControl('')},//, [Validators.maxLength(100)]],
+            {temperatureStabilization: new FormControl('')}, //, [Validators.required]],//, [Validators.maxLength(100)]],
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
@@ -55,8 +55,4 @@ export class GnssReceiversGroupComponent extends AbstractGroup<GnssReceiverViewM
     newItemViewModel(blank?: boolean): GnssReceiverViewModel {
         return new GnssReceiverViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return GnssReceiverItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -45,20 +45,20 @@ export class HumiditySensorItemComponent extends AbstractItem implements OnInit 
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {dataSamplingInterval: new FormControl(['', []])},
-            {accuracyPercentRelativeHumidity: new FormControl(['', []])},
-            {aspiration: new FormControl(['', []])},
-            {heightDiffToAntenna: new FormControl(['', []])},
-            {calibrationDate: new FormControl(['', []])},
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl('')},
+            {accuracyPercentRelativeHumidity: new FormControl('')},
+            {aspiration: new FormControl('')},
+            {heightDiffToAntenna: new FormControl('')},
+            {calibrationDate: new FormControl('')},
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { HumiditySensorViewModel } from './humidity-sensor-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,25 +35,31 @@ export class HumiditySensorItemComponent extends AbstractItem implements OnInit 
         return this.humiditySensor;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            manufacturer: [''],//, [Validators.required, Validators.minLength(100)]],
-            serialNumber: [''],//, [Validators.required, Validators.maxLength(100)]],
-            dataSamplingInterval: ['', []],
-            accuracyPercentRelativeHumidity: ['', []],
-            aspiration: ['', []],
-            heightDiffToAntenna: ['', []],
-            calibrationDate: ['', []],
-            startDate: [''],//, [Validators.required]],
-            endDate: ['', []],  // requiredIfNotCurrent="true"
-            notes: [''],//, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl(['', []])},
+            {accuracyPercentRelativeHumidity: new FormControl(['', []])},
+            {aspiration: new FormControl(['', []])},
+            {heightDiffToAntenna: new FormControl(['', []])},
+            {calibrationDate: new FormControl(['', []])},
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensors-group.component.ts
@@ -55,8 +55,4 @@ export class HumiditySensorsGroupComponent extends AbstractGroup<HumiditySensorV
     newItemViewModel(blank?: boolean): HumiditySensorViewModel {
         return new HumiditySensorViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return HumiditySensorItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.html
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.html
@@ -39,7 +39,7 @@
         </div>
         <div *ngIf=" localEpisodicEffect != null" [ngClass]="{'container-dirty': localEpisodicEffect.dateDeleted}">
             <text-input formControlName="event" controlName="event" [form]="itemGroup">Event</text-input>
-            <datetime-input formControlName="startDate" controlName="startDate" required="true" [form]="itemGroup">Date Installed (UTC)</datetime-input>
+            <datetime-input formControlName="startDate" controlName="startDate" [form]="itemGroup">Date Installed (UTC)</datetime-input>
             <datetime-input formControlName="endDate" controlName="endDate" [index]="index" [form]="itemGroup">Date Removed (UTC)</datetime-input>
         </div>
     </div>

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { LocalEpisodicEffectViewModel } from './local-episodic-effect-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -49,4 +49,25 @@ export class LocalEpisodicEffectItemComponent extends AbstractItem implements On
         });
         return itemGroup;
     }
+
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {event: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
+    }
+
 }

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
@@ -35,21 +35,6 @@ export class LocalEpisodicEffectItemComponent extends AbstractItem implements On
         return this.localEpisodicEffect;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            event: [''],//, [Validators.required, Validators.minLength(100)]],
-            startDate: [''],//, [Validators.required]],
-            endDate: ['', []],  // requiredIfNotCurrent="true"
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
-    }
-
     /**
      * Return the controls to become the form.
      *
@@ -60,13 +45,13 @@ export class LocalEpisodicEffectItemComponent extends AbstractItem implements On
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {event: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {event: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/local-episodic-effect/local-episodic-effects-group.component.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effects-group.component.ts
@@ -55,8 +55,4 @@ export class LocalEpisodicEffectsGroupComponent extends AbstractGroup<LocalEpiso
     newItemViewModel(blank?: boolean): LocalEpisodicEffectViewModel {
         return new LocalEpisodicEffectViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return LocalEpisodicEffectItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -45,19 +45,19 @@ export class PressureSensorItemComponent extends AbstractItem implements OnInit 
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {dataSamplingInterval: new FormControl(['', []])},
-            {accuracyHPa: new FormControl(['', []])},
-            {heightDiffToAntenna: new FormControl(['', []])},
-            {calibrationDate: new FormControl(['', []])},
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl('')},
+            {accuracyHPa: new FormControl('')},
+            {heightDiffToAntenna: new FormControl('')},
+            {calibrationDate: new FormControl('')},
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { PressureSensorViewModel } from './pressure-sensor-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,24 +35,30 @@ export class PressureSensorItemComponent extends AbstractItem implements OnInit 
         return this.pressureSensor;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            manufacturer: [''],//, [Validators.required, Validators.minLength(100)]],
-            serialNumber: [''],//, [Validators.required, Validators.maxLength(100)]],
-            dataSamplingInterval: ['', []],
-            accuracyHPa: ['', []],
-            heightDiffToAntenna: ['', []],
-            calibrationDate: ['', []],
-            startDate: [''],//, [Validators.required]],
-            endDate: ['', []],  // requiredIfNotCurrent="true"
-            notes: [''],//, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl(['', []])},
+            {accuracyHPa: new FormControl(['', []])},
+            {heightDiffToAntenna: new FormControl(['', []])},
+            {calibrationDate: new FormControl(['', []])},
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensors-group.component.ts
@@ -53,8 +53,4 @@ export class PressureSensorsGroupComponent extends AbstractGroup<PressureSensorV
     newItemViewModel(blank?: boolean): PressureSensorViewModel {
         return new PressureSensorViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return PressureSensorItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/responsible-party/responsible-party-group.component.ts
+++ b/src/client/app/responsible-party/responsible-party-group.component.ts
@@ -100,8 +100,4 @@ export class ResponsiblePartyGroupComponent extends AbstractGroup<ResponsiblePar
     newItemViewModel(blank?: boolean): ResponsiblePartyViewModel {
         return new ResponsiblePartyViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return ResponsiblePartyItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/responsible-party/responsible-party-item.component.ts
+++ b/src/client/app/responsible-party/responsible-party-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { ResponsiblePartyViewModel } from './responsible-party-view-model';
 import { ResponsiblePartyType } from './responsible-party-group.component';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -38,31 +38,36 @@ export class ResponsiblePartyItemComponent extends AbstractItem implements OnIni
         return this.responsibleParty;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-
-            individualName: [''],//, [Validators.required, Validators.minLength(100)]],
-            organisationName: [''],//, [Validators.required, Validators.maxLength(100)]],
-            positionName: ['', []],
-            deliveryPoint1: ['', []],
-            deliveryPoint2: ['', []],
-            city: ['', []],
-            administrativeArea: [''],//, [Validators.required]],
-            postalCode: ['', []],
-            country: [''], //, [Validators.maxLength(2000)]],
-            email1: '',
-            email2: '',
-            phone1: '',
-            phone2: '',
-            fax1: '',
-            fax2: '',
-            fieldMaps: '',
-            dateInserted: '',
-            dateDeleted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {individualName: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {organisationName: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {positionName: new FormControl(['', []])},
+            {deliveryPoint1: new FormControl(['', []])},
+            {deliveryPoint2: new FormControl(['', []])},
+            {city: new FormControl(['', []])},
+            {administrativeArea: new FormControl([''])},//, [Validators.required]],
+            {postalCode: new FormControl(['', []])},
+            {country: new FormControl([''])}, //, [Validators.maxLength(2000)]],
+            {email1: new FormControl('')},
+            {email2: new FormControl('')},
+            {phone1: new FormControl('')},
+            {phone2: new FormControl('')},
+            {fax1: new FormControl('')},
+            {fax2: new FormControl('')},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/responsible-party/responsible-party-item.component.ts
+++ b/src/client/app/responsible-party/responsible-party-item.component.ts
@@ -48,15 +48,15 @@ export class ResponsiblePartyItemComponent extends AbstractItem implements OnIni
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {individualName: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {organisationName: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {positionName: new FormControl(['', []])},
-            {deliveryPoint1: new FormControl(['', []])},
-            {deliveryPoint2: new FormControl(['', []])},
-            {city: new FormControl(['', []])},
-            {administrativeArea: new FormControl([''])},//, [Validators.required]],
-            {postalCode: new FormControl(['', []])},
-            {country: new FormControl([''])}, //, [Validators.maxLength(2000)]],
+            {individualName: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {organisationName: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {positionName: new FormControl('')},
+            {deliveryPoint1: new FormControl('')},
+            {deliveryPoint2: new FormControl('')},
+            {city: new FormControl('')},
+            {administrativeArea: new FormControl('')},//, [Validators.required]],
+            {postalCode: new FormControl('')},
+            {country: new FormControl('')}, //, [Validators.maxLength(2000)]],
             {email1: new FormControl('')},
             {email2: new FormControl('')},
             {phone1: new FormControl('')},
@@ -64,9 +64,9 @@ export class ResponsiblePartyItemComponent extends AbstractItem implements OnIni
             {fax1: new FormControl('')},
             {fax2: new FormControl('')},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/shared/abstract-groups-items/abstract-group.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.ts
@@ -99,11 +99,6 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
     abstract compare(obj1: AbstractViewModel, obj2: AbstractViewModel): number;
 
     /**
-     * @return the Item form instance to be inserted in the Group array.
-     */
-    abstract newItemFormInstance(): FormGroup;
-
-    /**
      * Event mechanism to communicate with children.  Simply change the value of this and the children detect the change.
      *
      * @returns {GeodesyEvent}
@@ -217,6 +212,7 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
      * @param itemsArrayName that is set on the siteInfoForm
      */
     setupForm(itemsArrayName: string) {
+        console.debug(`setupForm ${itemsArrayName}`);
         this.groupArrayForm = this.formBuilder.array([]);
         if (this.siteInfoForm.controls[itemsArrayName]) {
             this.siteInfoForm.removeControl(itemsArrayName);
@@ -238,7 +234,8 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
      * @param isItDirty if to mark it dirty or not.
      */
     addChildItemToForm(isItDirty: boolean = false) {
-        let itemGroup: FormGroup = this.newItemFormInstance();
+        // let itemGroup: FormGroup = this.newItemFormInstance();
+        let itemGroup: FormGroup = this.formBuilder.group({});
         if (sortingDirectionAscending) {
             this.groupArrayForm.push(itemGroup);
         } else {

--- a/src/client/app/shared/abstract-groups-items/abstract-group.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.ts
@@ -329,10 +329,16 @@ export abstract class AbstractGroup<T extends AbstractViewModel> {
         }
         updatedValue = this.itemProperties[index].setFinalValuesBeforeCreatingNewItem();
         if (updatedValue && Object.keys(updatedValue).length > 0) {
-            this.groupArrayForm.at(index).patchValue(updatedValue);
-            this.groupArrayForm.at(index).markAsDirty();
-            for (let key of Object.keys(updatedValue)) {
-                (<FormGroup>this.groupArrayForm.at(index)).controls[key].markAsDirty();
+            let formGroup: FormGroup = <FormGroup>this.groupArrayForm.at(index);
+            formGroup.patchValue(updatedValue);
+            formGroup.markAsDirty();
+            // If the Group hasn't been opened, no form controls will exist.  It is unusual for users to create a new Item without
+            // looking at whatever normally exists.  If not opened then the modified fields won't get marked as dirty.
+            // It this is a problem then we could create the form controls (see AbstractItem.patchForm())
+            if (Object.keys(formGroup.controls).length > 0) {
+                for (let key of Object.keys(updatedValue)) {
+                    (<FormGroup>this.groupArrayForm.at(index)).controls[key].markAsDirty();
+                }
             }
         }
     }

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -315,7 +315,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
                 console.log('  and siteLogOrigin: ', this.siteLogOrigin);
             } else {
                 this.siteLogService.sendFormModifiedStateMessage(false);
-                console.log('form dirty - no');
+                console.log('form dirty - no: ', value);
             }
         });
     }

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { SurveyedLocalTieViewModel } from './surveyed-local-tie-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,26 +35,32 @@ export class SurveyedLocalTieItemComponent extends AbstractItem implements OnIni
         return this.surveyedLocalTie;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            tiedMarkerName: [''],//, [Validators.required, Validators.maxLength(100)]],
-            tiedMarkerUsage: [''],//, [Validators.maxLength(100)]],
-            tiedMarkerCDPNumber: [''],//, [Validators.maxLength(100)]],
-            tiedMarkerDOMESNumber: [''],//, [Validators.maxLength(100)]],
-            dx: [''],//, [Validators.maxLength(100)]],
-            dy: [''],//, [Validators.maxLength(100)]],
-            dz: [''],//, [Validators.maxLength(100)]],
-            surveyMethod: [''],//, [Validators.maxLength(100)]],
-            localSiteTiesAccuracy: [''],//, [Validators.maxLength(100)]],
-            dateMeasured: [''],//, [Validators.maxLength(100)]],
-            notes: [''],//, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {tiedMarkerName: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {tiedMarkerUsage: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {tiedMarkerCDPNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {tiedMarkerDOMESNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dx: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dy: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dz: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {surveyMethod: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {localSiteTiesAccuracy: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {dateMeasured: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -45,21 +45,21 @@ export class SurveyedLocalTieItemComponent extends AbstractItem implements OnIni
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {tiedMarkerName: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {tiedMarkerUsage: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {tiedMarkerCDPNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {tiedMarkerDOMESNumber: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dx: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dy: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dz: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {surveyMethod: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {localSiteTiesAccuracy: new FormControl([''])},//, [Validators.maxLength(100)]],
-            {dateMeasured: new FormControl([''])},//, [Validators.maxLength(100)]],
+            {tiedMarkerName: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {tiedMarkerUsage: new FormControl('')},//, [Validators.maxLength(100)]],
+            {tiedMarkerCDPNumber: new FormControl('')},//, [Validators.maxLength(100)]],
+            {tiedMarkerDOMESNumber: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dx: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dy: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dz: new FormControl('')},//, [Validators.maxLength(100)]],
+            {surveyMethod: new FormControl('')},//, [Validators.maxLength(100)]],
+            {localSiteTiesAccuracy: new FormControl('')},//, [Validators.maxLength(100)]],
+            {dateMeasured: new FormControl('')},//, [Validators.maxLength(100)]],
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
@@ -57,8 +57,4 @@ export class SurveyedLocalTiesGroupComponent extends AbstractGroup<SurveyedLocal
     newItemViewModel(blank?: boolean): SurveyedLocalTieViewModel {
         return new SurveyedLocalTieViewModel();
     }
-
-    newItemFormInstance(): FormGroup {
-        return SurveyedLocalTieItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { TemperatureSensorViewModel } from './temperature-sensor-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,24 +35,30 @@ export class TemperatureSensorItemComponent extends AbstractItem implements OnIn
         return this.temperatureSensor;
     }
 
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            manufacturer: [''],//, [Validators.required, Validators.minLength(100)]],
-            serialNumber: [''],//, [Validators.required, Validators.maxLength(100)]],
-            dataSamplingInterval: ['', []],
-            accuracyDegreesCelcius: ['', []],
-            heightDiffToAntenna: ['', []],
-            calibrationDate: ['', []],
-            startDate: [''],//, [Validators.required]],
-            endDate: ['', []],  // requiredIfNotCurrent="true"
-            notes: [''], //, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl(['', []])},
+            {accuracyDegreesCelcius: new FormControl(['', []])},
+            {heightDiffToAntenna: new FormControl(['', []])},
+            {calibrationDate: new FormControl(['', []])},
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -45,19 +45,19 @@ export class TemperatureSensorItemComponent extends AbstractItem implements OnIn
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {dataSamplingInterval: new FormControl(['', []])},
-            {accuracyDegreesCelcius: new FormControl(['', []])},
-            {heightDiffToAntenna: new FormControl(['', []])},
-            {calibrationDate: new FormControl(['', []])},
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl(['', []])},  // requiredIfNotCurrent="true"
+            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {dataSamplingInterval: new FormControl('')},
+            {accuracyDegreesCelcius: new FormControl('')},
+            {heightDiffToAntenna: new FormControl('')},
+            {calibrationDate: new FormControl('')},
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/temperature-sensor/temperature-sensors-group.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensors-group.component.ts
@@ -54,8 +54,4 @@ export class TemperatureSensorsGroupComponent extends AbstractGroup<TemperatureS
     newItemViewModel(blank?: boolean): TemperatureSensorViewModel {
         return new TemperatureSensorViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return TemperatureSensorItemComponent.newFormInstance(this.formBuilder);
-    }
 }

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -45,17 +45,17 @@ export class WaterVaporSensorItemComponent extends AbstractItem implements OnIni
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
-            {heightDiffToAntenna: new FormControl([''])},
-            {calibrationDate: new FormControl([''])},
-            {startDate: new FormControl([''])},//, [Validators.required]],
-            {endDate: new FormControl([''])},  // requiredIfNotCurrent="true"
+            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {heightDiffToAntenna: new FormControl('')},
+            {calibrationDate: new FormControl('')},
+            {startDate: new FormControl('')},//, [Validators.required]],
+            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {fieldMaps: new FormControl('')},
-            {dateDeleted: new FormControl([''])},
-            {dateInserted: new FormControl([''])},
-            {deletedReason: new FormControl([''])}
+            {dateDeleted: new FormControl('')},
+            {dateInserted: new FormControl('')},
+            {deletedReason: new FormControl('')}
         ]);
     }
 

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup } from '@angular/forms';
-import { AbstractItem } from '../shared/abstract-groups-items/abstract-item';
+import { FormBuilder, Validators, FormGroup, FormControl } from '@angular/forms';
+import { AbstractItem, ItemControls } from '../shared/abstract-groups-items/abstract-item';
 import { WaterVaporSensorViewModel } from './water-vapor-sensor-view-model';
 import { DialogService } from '../shared/index';
 import { AbstractViewModel } from '../shared/json-data-view-model/view-model/abstract-view-model';
@@ -35,23 +35,28 @@ export class WaterVaporSensorItemComponent extends AbstractItem implements OnIni
         return this.waterVaporSensor;
     }
 
-
-    public static newFormInstance(formBuilder: FormBuilder): FormGroup {
-        let itemGroup: FormGroup = formBuilder.group({
-            // turn off all Validators until work out solution to 'was false now true' problem
-            // TODO Fix Validators
-            manufacturer: [''],//, [Validators.required, Validators.minLength(100)]],
-            serialNumber: [''],//, [Validators.required, Validators.maxLength(100)]],
-            heightDiffToAntenna: [''],
-            calibrationDate: [''],
-            startDate: [''],//, [Validators.required]],
-            endDate: [''],  // requiredIfNotCurrent="true"
-            notes: [''],//, [Validators.maxLength(2000)]],
-            fieldMaps: '',
-            dateDeleted: '',
-            dateInserted: '',
-            deletedReason: ''
-        });
-        return itemGroup;
+    /**
+     * Return the controls to become the form.
+     *
+     * @return array of AbstractControl objects
+     */
+    getFormControls(): ItemControls {
+        // let itemGroup: FormGroup = formBuilder.group({
+        // turn off all Validators until work out solution to 'was false now true' problem
+        // TODO Fix Validators
+        return new ItemControls([
+            {manufacturer: new FormControl([''])},//, [Validators.required, Validators.minLength(100)]],
+            {serialNumber: new FormControl([''])},//, [Validators.required, Validators.maxLength(100)]],
+            {heightDiffToAntenna: new FormControl([''])},
+            {calibrationDate: new FormControl([''])},
+            {startDate: new FormControl([''])},//, [Validators.required]],
+            {endDate: new FormControl([''])},  // requiredIfNotCurrent="true"
+            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {fieldMaps: new FormControl('')},
+            {dateDeleted: new FormControl([''])},
+            {dateInserted: new FormControl([''])},
+            {deletedReason: new FormControl([''])}
+        ]);
     }
+
 }

--- a/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensors-group.component.ts
@@ -53,8 +53,4 @@ export class WaterVaporSensorsGroupComponent extends AbstractGroup<WaterVaporSen
     newItemViewModel(blank?: boolean): WaterVaporSensorViewModel {
         return new WaterVaporSensorViewModel(blank);
     }
-
-    newItemFormInstance(): FormGroup {
-        return WaterVaporSensorItemComponent.newFormInstance(this.formBuilder);
-    }
 }


### PR DESCRIPTION
Changed to doing 'lazy loaded' forms by not creating the form controls until the Group is opened.

The reason for this is because prior to this change, the forms with all controls were being created and which didn't get populated until the Group was opened.  So when you saved, the blank default fields from all the forms under Groups that hadn't been opened were updating the legitimate values in the SiteLogModel.
