### PR TITLE
In angular forms, `!valid` does not imply `invalid`

### DIFF
--- a/src/client/app/site-info/site-identification.component.ts
+++ b/src/client/app/site-info/site-identification.component.ts
@@ -64,7 +64,7 @@ export class SiteIdentificationComponent implements OnInit {
     }
 
     public isFormInvalid(): boolean {
-        return this.siteIdentificationForm ? ! this.siteIdentificationForm.valid : false;
+        return this.siteIdentificationForm.invalid;
     }
 
     private setupForm() {

--- a/src/client/app/site-info/site-info.component.ts
+++ b/src/client/app/site-info/site-info.component.ts
@@ -262,7 +262,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     }
 
     public isFormInvalid(): boolean {
-        return this.siteInfoForm ? !this.siteInfoForm.valid : false;
+        return this.siteInfoForm.invalid;
     }
 
     public isSiteInformationFormDirty(): boolean {
@@ -270,7 +270,7 @@ export class SiteInfoComponent implements OnInit, OnDestroy {
     }
 
     public isSiteInformationFormInvalid(): boolean {
-        return this.siteInformationForm ? !this.siteInformationForm.valid : false;
+        return this.siteInformationForm.invalid;
     }
 
     private setupForm() {

--- a/src/client/app/site-info/site-location.component.ts
+++ b/src/client/app/site-info/site-location.component.ts
@@ -54,7 +54,7 @@ export class SiteLocationComponent implements OnInit, OnDestroy {
     }
 
     public isFormInvalid(): boolean {
-        return this.siteLocationForm ? ! this.siteLocationForm.valid : false;
+        return this.siteLocationForm.invalid;
     }
 
     private setupForm() {


### PR DESCRIPTION
Flag `valid` is set after successful validation. A disabled form, for
instance, is neither valid nor invalid, because validation is not run on
disabled forms. Also, checking `siteLocationForm` seems unnecessary.