### PR TITLE
This is not patching

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -315,7 +315,7 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
             formGroup.markAsDirty();
             // If the Group hasn't been opened, no form controls will exist.  It is unusual for users to create a new Item without
             // looking at whatever normally exists.  If not opened then the modified fields won't get marked as dirty.
-            // It this is a problem then we could create the form controls (see AbstractItem.patchForm())
+            // It this is a problem then we could create the form controls.
             if (Object.keys(formGroup.controls).length > 0) {
                 for (let key of Object.keys(updatedValue)) {
                     (<FormGroup>this.groupArrayForm.at(index)).controls[key].markAsDirty();

--- a/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
@@ -117,7 +117,22 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
     abstract getFormControls(): ItemControls;
 
     ngOnInit() {
-        this.patchForm();
+        this.itemGroup = <FormGroup> this.groupArray.at(this.index);
+        this.addFields(this.itemGroup, this.getFormControls());
+        // For some reason, when - Open Group, Open Item, Close Group, Reopen Group, it is being marked as dirty
+        // NOTE that without the setTimeout() on the setValue(), a "was false now true" error occurs.  It seems that
+        // it is talking about the dirty status.  So something is happening deep in the angular lifecycle.  Hopefully
+        // they fix this.
+        // Check its dirty status before doing the setValue() and restore to that state afterwards
+        let wasDirty: boolean = this.itemGroup ? this.itemGroup.dirty : true;   // True because it is new
+        setTimeout(() => {
+            this.itemGroup.setValue(this.getItem());
+        });
+        if (!wasDirty) {
+            setTimeout(() => {
+                this.itemGroup.markAsPristine();
+            });
+        }
     }
 
     /**
@@ -181,28 +196,6 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
 
     public isFormInvalid(): boolean {
         return this.itemGroup && this.itemGroup.invalid;
-    }
-
-    /**
-     * Patching (or setting) is used to apply the values in the model to the form.
-     */
-    protected patchForm(): void {
-        this.itemGroup = <FormGroup> this.groupArray.at(this.index);
-        this.addFields(this.itemGroup, this.getFormControls());
-        // For some reason, when - Open Group, Open Item, Close Group, Reopen Group, it is being marked as dirty
-        // NOTE that without the setTimeout() on the setValue(), a "was false now true" error occurs.  It seems that
-        // it is talking about the dirty status.  So something is happening deep in the angular lifecycle.  Hopefully
-        // they fix this.
-        // Check its dirty status before doing the setValue() and restore to that state afterwards
-        let wasDirty: boolean = this.itemGroup ? this.itemGroup.dirty : true;   // True because it is new
-        setTimeout(() => {
-            this.itemGroup.setValue(this.getItem());
-        });
-        if (!wasDirty) {
-            setTimeout(() => {
-                this.itemGroup.markAsPristine();
-            });
-        }
     }
 
     /**

--- a/src/client/app/site-log/site-location.component.ts
+++ b/src/client/app/site-log/site-location.component.ts
@@ -38,7 +38,7 @@ export class SiteLocationComponent implements OnInit {
         if (siteLogModel && Object.keys(siteLogModel).length > 0) {
             this.siteLocation = siteLogModel.siteLocation;
             this.changeDetectionRef.detectChanges();
-            this.patchForm();
+            this.siteLocationForm.setValue(this.siteLocation);
         }
     }
 
@@ -62,7 +62,6 @@ export class SiteLocationComponent implements OnInit {
 
     ngOnInit() {
         this.setupForm();
-        // patchForm is called from the setter in this form
     }
 
     public isFormDirty(): boolean {
@@ -93,10 +92,6 @@ export class SiteLocationComponent implements OnInit {
             this.siteLocationForm.disable();
         }
         this.parentForm.addControl('siteLocation', this.siteLocationForm);
-    }
-
-    private patchForm() {
-        this.siteLocationForm.setValue(this.siteLocation);
     }
 }
 


### PR DESCRIPTION
The code in `patchForm` function does not perform any patching. Instead, it sets up the form controls, the dirty state, and sets the form values -- a perfect mix of work for the generic `ngOnInit`.

