### PR TITLE
added guard for field maps not existing

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -265,7 +265,7 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
         }
         this.itemProperties.splice(itemIndex, 1);
         this.itemOriginalProperties.splice(itemIndex, 1);
-        this.groupArrayForm.value.splice(itemIndex, 1);
+        this.groupArrayForm.controls.splice(itemIndex, 1);
     }
 
     public isFormDirty(): boolean {

--- a/src/client/app/shared/json-data-view-model/json-view-model.service.ts
+++ b/src/client/app/shared/json-data-view-model/json-view-model.service.ts
@@ -150,12 +150,10 @@ export class JsonViewModelService {
     private viewToDataModel<T extends AbstractViewModel>(viewModels: T[]): any[] {
         let dataModels: any[] = [];
         for (let viewModel of viewModels) {
-            if ((<T> viewModel).getFieldMaps) {
-                let fieldMappings: FieldMap[] = (<T> viewModel).getFieldMaps();
-                let dataModel: any = {};
-                DataViewTranslatorService.translateV2D(viewModel, dataModel, fieldMappings);
-                dataModels.push(dataModel);
-            }
+            let fieldMappings: FieldMap[] = (<T> viewModel).getFieldMaps();
+            let dataModel: any = {};
+            DataViewTranslatorService.translateV2D(viewModel, dataModel, fieldMappings);
+            dataModels.push(dataModel);
         }
         return dataModels;
     }

--- a/src/client/app/shared/json-data-view-model/json-view-model.service.ts
+++ b/src/client/app/shared/json-data-view-model/json-view-model.service.ts
@@ -150,10 +150,12 @@ export class JsonViewModelService {
     private viewToDataModel<T extends AbstractViewModel>(viewModels: T[]): any[] {
         let dataModels: any[] = [];
         for (let viewModel of viewModels) {
-            let fieldMappings: FieldMap[] = (<T> viewModel).getFieldMaps();
-            let dataModel: any = {};
-            DataViewTranslatorService.translateV2D(viewModel, dataModel, fieldMappings);
-            dataModels.push(dataModel);
+            if ((<T> viewModel).getFieldMaps) {
+                let fieldMappings: FieldMap[] = (<T> viewModel).getFieldMaps();
+                let dataModel: any = {};
+                DataViewTranslatorService.translateV2D(viewModel, dataModel, fieldMappings);
+                dataModels.push(dataModel);
+            }
         }
         return dataModels;
     }


### PR DESCRIPTION
I am still not sure why "getFieldMaps" is not a function... maybe the new record is not a fully-fledged view model at that stage (and when you cancel one it isn't removing it from the site log view model)

I'm not sure whether this is masking a code smell or not, it does prevent the error and conceptually seems ok to me:

"In the case where there is a view model that does not have mapped fields for some reason, don't try and create a data model out of it."