### PR TITLE
Date time bug g426 try2

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-view-model.ts
+++ b/src/client/app/frequency-standard/frequency-standard-view-model.ts
@@ -18,10 +18,10 @@ export class FrequencyStandardViewModel extends AbstractViewModel {
 
     createFieldMappings(): void {
         this.addFieldMapping('/frequencyStandard/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
-            'string', '/startDate', 'string');
+            'string', '/startDate', 'date');
 
         this.addFieldMapping('/frequencyStandard/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
-            'string', '/endDate', 'string');
+            'string', '/endDate', 'date');
 
         this.addFieldMapping('/frequencyStandard/standardType/value', 'string',
             '/standardType', 'string');

--- a/src/client/app/gnss-antenna/gnss-antenna-view-model.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-view-model.ts
@@ -36,8 +36,8 @@ export class GnssAntennaViewModel extends AbstractViewModel {
     }
 
     createFieldMappings(): void {
-        this.addFieldMapping('/gnssAntenna/dateInstalled/value/0', 'string', '/startDate', 'string');
-        this.addFieldMapping('/gnssAntenna/dateRemoved/value/0', 'string', '/endDate', 'string');
+        this.addFieldMapping('/gnssAntenna/dateInstalled/value/0', 'string', '/startDate', 'date');
+        this.addFieldMapping('/gnssAntenna/dateRemoved/value/0', 'string', '/endDate', 'date');
         this.addFieldMapping('/gnssAntenna/igsModelCode/value', 'string', '/antennaType', 'string');
         this.addFieldMapping('/gnssAntenna/manufacturerSerialNumber', 'string', '/serialNumber', 'string');
         this.addFieldMapping('/gnssAntenna/antennaReferencePoint/value', 'string', '/antennaReferencePoint', 'string');

--- a/src/client/app/gnss-receiver/gnss-receiver-view-model.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-view-model.ts
@@ -34,8 +34,8 @@ export class GnssReceiverViewModel extends AbstractViewModel {
         this.addFieldMapping('/gnssReceiver/satelliteSystem/0/value', 'string', '/satelliteSystem', 'string');
         this.addFieldMapping('/gnssReceiver/elevationCutoffSetting', 'string', '/elevationCutoffSetting', 'number');
         this.addFieldMapping('/gnssReceiver/temperatureStabilization', 'string', '/temperatureStabilization', 'number');
-        this.addFieldMapping('/gnssReceiver/dateInstalled/value/0', 'string', '/startDate', 'string');
-        this.addFieldMapping('/gnssReceiver/dateRemoved/value/0', 'string', '/endDate', 'string');
+        this.addFieldMapping('/gnssReceiver/dateInstalled/value/0', 'string', '/startDate', 'date');
+        this.addFieldMapping('/gnssReceiver/dateRemoved/value/0', 'string', '/endDate', 'date');
         this.addFieldMapping('/gnssReceiver/notes', 'string', '/notes', 'string');
     };
 }

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
@@ -29,14 +29,14 @@ export class HumiditySensorViewModel extends AbstractViewModel {
     createFieldMappings(): void {
         this.addFieldMapping('/humiditySensor/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
             'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/humiditySensor/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
             'string',
-            '/endDate', 'string');
+            '/endDate', 'date');
 
         this.addFieldMapping('/humiditySensor/calibrationDate/value/0', 'string',
-            '/calibrationDate', 'string');
+            '/calibrationDate', 'date');
 
         this.addFieldMapping('/humiditySensor/dataSamplingInterval', 'string',
             '/dataSamplingInterval', 'number');

--- a/src/client/app/local-episodic-effect/local-episodic-effect-view-model.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-view-model.ts
@@ -15,11 +15,11 @@ export class LocalEpisodicEffectViewModel extends AbstractViewModel {
     createFieldMappings(): void {
         this.addFieldMapping('/localEpisodicEffect/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
             'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/localEpisodicEffect/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
             'string',
-            '/endDate', 'string');
+            '/endDate', 'date');
 
         this.addFieldMapping('/localEpisodicEffect/event', 'string',
             '/event', 'string');

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
@@ -29,14 +29,14 @@ export class PressureSensorViewModel extends AbstractViewModel {
     createFieldMappings(): void {
         this.addFieldMapping('/pressureSensor/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
             'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/pressureSensor/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
             'string',
-            '/endDate', 'string');
+            '/endDate', 'date');
 
         this.addFieldMapping('/pressureSensor/calibrationDate/value/0', 'string',
-            '/calibrationDate', 'string');
+            '/calibrationDate', 'date');
 
         this.addFieldMapping('/pressureSensor/dataSamplingInterval', 'string',
             '/dataSamplingInterval', 'number');

--- a/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
@@ -207,8 +207,9 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
      */
     public getItemHeaderHtml(): string {
 
-        let startDatetime = this.getItem().startDate;
-        let endDatetime = this.getItem().endDate;
+        // TODO - change view model to be exclusively Date and fix this
+        let startDatetime: any = this.getItem().startDate;
+        let endDatetime: any = this.getItem().endDate;
 
         let headerHtml: string = '<span class="hidden-xsm">'
                                + (this.getIndex() === 0 ? 'Current' : 'Previous')
@@ -217,10 +218,14 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
         if (startDatetime) {
             headerHtml += '<span class="hidden-xxs">' + this.getItemName() + ' </span>';
             let dateRange: string = '';
+            let startDateString: string = MiscUtils.isDate(startDatetime) ? MiscUtils.formatDateToDateString(startDatetime):
+                MiscUtils.getDateComponent(startDatetime);
             if (endDatetime) {
-                dateRange = MiscUtils.getDate(startDatetime) + ' &ndash; ' + MiscUtils.getDate(endDatetime);
+                let endDateString: string = MiscUtils.isDate(endDatetime) ? MiscUtils.formatDateToDateString(endDatetime):
+                    MiscUtils.getDateComponent(endDatetime);
+                dateRange = endDateString + ' &ndash; ' + startDateString;
             } else {
-                dateRange = 'Since ' + MiscUtils.getDate(startDatetime);
+                dateRange = 'Since ' + startDateString;
             }
             headerHtml += '<span class="hidden-xxs">(</span>' + dateRange + '<span class="hidden-xxs">)</span>';
         } else {

--- a/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
+++ b/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
@@ -37,7 +37,7 @@ export abstract class AbstractGnssControls {
         } else {
             dirty = control.dirty;
         }
-        console.warn('  isDirty Control "' + controlId + '": '+ dirty + ' - ', control);
+        // console.warn('  isDirty Control "' + controlId + '": '+ dirty + ' - ', control);
         return dirty;
     }
 
@@ -50,7 +50,7 @@ export abstract class AbstractGnssControls {
         } else {
             valid = control.valid;
         }
-        console.warn('  isValid Control "' + controlId + '": '+ valid + ' - ', control);
+        // console.warn('  isValid Control "' + controlId + '": '+ valid + ' - ', control);
         return valid;
     }
 

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
@@ -8,11 +8,6 @@
       <div class="input-group">
                <!--[formControlName]="controlName"-->
           <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName), 'labeldisabled': isFormDisabled()}">{{datetime}}</label>
-          <!--<input type="text" maxlength="24"
-               class="form-control z-lowest"
-               [(ngModel)]="datetimeDisplay"
-               (change)="updateCalendar()"
-               (focus)="miscUtils.scrollIntoView($event, showDatetimePicker); showDatetimePicker = true;"/>-->
         <span class="input-group-btn z-lowest">
           <button id="calendar-btn" type="button"
                   class="btn btn-default btn-calendar z-lowest"
@@ -37,13 +32,11 @@
                                     <span class="glyphicon glyphicon-chevron-up"></span>
                                 </a>
                             </td>
-                            <td>&nbsp;</td>
                             <td>
                                 <a (click)="incrementMinutes()" class="btn btn-time">
                                     <span class="glyphicon glyphicon-chevron-up"></span>
                                 </a>
                             </td>
-                            <td>&nbsp;</td>
                             <td>
                                 <a (click)="incrementSeconds()" class="btn btn-time">
                                     <span class="glyphicon glyphicon-chevron-up"></span>
@@ -60,25 +53,6 @@
                             <td class="form-group">
                                 <label class="form-control text-center input-time">{{getSeconds()}}</label>
                             </td>
-<!--
-                            <td class="form-group" [ngClass]="{'has-error': invalidHours}">
-                                <input type="text" [(ngModel)]="hoursString"
-                                       (change)="updateHours()"
-                                       class="form-control text-center input-time" maxlength="2">
-                            </td>
-                            <td>:</td>
-                            <td class="form-group" [ngClass]="{'has-error': invalidMinutes}">
-                                <input type="text" [(ngModel)]="minutesString"
-                                       (change)="updateMinutes()"
-                                       class="form-control text-center input-time" maxlength="2">
-                            </td>
-                            <td>:</td>
-                            <td class="form-group" [ngClass]="{'has-error': invalidSeconds}">
-                                <input type="text" [(ngModel)]="secondsString"
-                                       (change)="updateSeconds()"
-                                       class="form-control text-center input-time" maxlength="2">
-                            </td>
--->
                         </tr>
                         <tr class="text-center">
                             <td>
@@ -86,13 +60,11 @@
                                     <span class="glyphicon glyphicon-chevron-down"></span>
                                 </a>
                             </td>
-                            <td>&nbsp;</td>
                             <td>
                                 <a (click)="decrementMinutes()" class="btn btn-time">
                                     <span class="glyphicon glyphicon-chevron-down"></span>
                                 </a>
                             </td>
-                            <td>&nbsp;</td>
                             <td>
                                 <a (click)="decrementSeconds()" class="btn btn-time">
                                     <span class="glyphicon glyphicon-chevron-down"></span>
@@ -104,13 +76,13 @@
                 </div>
                 <div class="center-btns">
                     <button class="btn btn-ok"
-                            (click)="setSelectedDatetime()"
+                            (click)="closeDatetime()"
                             title="Set selected date/time and close calendar">
                         <i class="glyphicon glyphicon-ok"></i>
                         OK
                     </button>
                     <button class="btn btn-cancel pull-right"
-                            (click)="cancelSelectedDatetime()"
+                            (click)="closeDatetime()"
                             title="Cancel selected date/time and close calendar">
                         <i class="glyphicon glyphicon-remove"></i>
                         Cancel

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
@@ -7,7 +7,7 @@
     <div>
       <div class="input-group">
                <!--[formControlName]="controlName"-->
-          <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName)}">{{datetime}}</label>
+          <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName), 'labeldisabled': isFormDisabled()}">{{datetime}}</label>
           <!--<input type="text" maxlength="24"
                class="form-control z-lowest"
                [(ngModel)]="datetimeDisplay"
@@ -16,7 +16,8 @@
         <span class="input-group-btn z-lowest">
           <button id="calendar-btn" type="button"
                   class="btn btn-default btn-calendar z-lowest"
-                  (click)="showDatetimePicker = miscUtils.scrollIntoView($event, showDatetimePicker)">
+                  (click)="showDatetimePicker = miscUtils.scrollIntoView($event, showDatetimePicker)"
+                  [disabled]="isFormDisabled()" >
             <span id="calendar-icon" class="glyphicon glyphicon-calendar"></span>
           </button>
         </span>

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
@@ -1,4 +1,4 @@
-<div class="form-group"> <!-- [formGroup]="form"-->
+<div class="form-group" [formGroup]="form">
   <label class="col-md-4 col-sm-4 col-xs-5 col-xxs-12 control-label" [ngClass]="{required: isRequired()}">
       <ng-content></ng-content>
   </label>
@@ -7,11 +7,12 @@
     <div>
       <div class="input-group">
                <!--[formControlName]="controlName"-->
-        <input type="text" maxlength="24"
+          <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName)}">{{datetime}}</label>
+          <!--<input type="text" maxlength="24"
                class="form-control z-lowest"
                [(ngModel)]="datetimeDisplay"
                (change)="updateCalendar()"
-               (focus)="miscUtils.scrollIntoView($event, showDatetimePicker); showDatetimePicker = true;"/>
+               (focus)="miscUtils.scrollIntoView($event, showDatetimePicker); showDatetimePicker = true;"/>-->
         <span class="input-group-btn z-lowest">
           <button id="calendar-btn" type="button"
                   class="btn btn-default btn-calendar z-lowest"
@@ -23,7 +24,7 @@
             <small>{{getErrorReport(controlName)}}</small>
 
             <div class="calendar-popup" *ngIf="showDatetimePicker">
-                <datepicker [(ngModel)]="datetimeModel"
+                <datepicker [formControlName]="controlName"
                             [showWeeks]="false"
                             (selectionDone)="updateDate($event)"></datepicker>
                 <div class="center-time">
@@ -49,6 +50,16 @@
                             </td>
                         </tr>
                         <tr>
+                            <td class="form-group">
+                                <label class="form-control text-center input-time">{{getHours()}}</label>
+                            </td>
+                            <td class="form-group">
+                                <label class="form-control text-center input-time">{{getMinutes()}}</label>
+                            </td>
+                            <td class="form-group">
+                                <label class="form-control text-center input-time">{{getSeconds()}}</label>
+                            </td>
+<!--
                             <td class="form-group" [ngClass]="{'has-error': invalidHours}">
                                 <input type="text" [(ngModel)]="hoursString"
                                        (change)="updateHours()"
@@ -66,6 +77,7 @@
                                        (change)="updateSeconds()"
                                        class="form-control text-center input-time" maxlength="2">
                             </td>
+-->
                         </tr>
                         <tr class="text-center">
                             <td>

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -74,36 +74,13 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     @Input() controlName: string;
 
     public _datetime: string = '';
-    public _datetimeLast: string = '';
-    public _datetimeDate: Date;
-
-    // public datetimeModel: Date;
-    //
-    // public hoursString: string = '00';
-    // public minutesString: string = '00';
-    // public secondsString: string = '00';
-
-    public invalidHours: boolean = false;
-    public invalidMinutes: boolean = false;
-    public invalidSeconds: boolean = false;
     public showDatetimePicker: boolean = false;
-    public hasChanges: boolean = false;
-    public invalidDatetime: boolean = false;
 
     public miscUtils: any = MiscUtils;
 
     isFormDisabled(): boolean {
         return this.form.disabled;
     }
-
-    // private _datetimeDisplay: string = '';
-    // private _datetimeDisplayLast: string = '';
-    // private hours: number = 0;
-    // private minutes: number = 0;
-    // private seconds: number = 0;
-
-    // private datetimeSuffix: string = '.000Z';
-    // private datetimeLast: string = '';
 
     static formatTimeToDisplay(dateStr: string, returnAsIsUponFailure: boolean = false): string {
         let datetimeDisplay: string = '';
@@ -171,6 +148,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     //     return this._datetimeDisplay;
     // }
 
+    // TODO - needs fixing to handle TimeZones
     set datetime(dt: string) {
         if (dt !== this._datetime) {
             // The datePicker sets its ngModel to formats like 'Sun 24th may 2016' or the like.  Convert.
@@ -181,7 +159,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             // this._datetimeLast = dt;    //this._datetime;
             this._datetime = dateString;
             // this._datetimeDate = d;
-            console.debug(`${this.controlName} - set datetime - set to ${dateString}, _datetimeDate is ${this._datetimeDate} - _datetimeLast is ${this._datetimeLast}`)
+            console.debug(`${this.controlName} - set datetime - set to ${dateString} from ${dt} string`)
             // this._datetimeDisplay = DatetimeInputComponent.formatTimeToDisplay(dt);
             // this.datetimeModel = new Date();
             this.propagateChange(this._datetime);
@@ -281,9 +259,23 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
      * Update the datetime model when users select a date on calendar
      */
     public updateDate(event: any): void {
-        let d: Date = new Date(String(event));
-        this.datetime = MiscUtils.formatDateToDatetimeString(d);
-        console.debug(`updateDate to ${d} - dateTime is now: ${this.datetime}`);
+        // TODO - fix time zone handling.  The DateTime widget will correct the date string to local timezone.
+        // TODO - I've been trying to mess around with forcing to Z / UTC but DateTime assumes local timezone.
+        // TODO - To prevent TZ problem use something like moment and moment-timezone
+        // TODO - Also see 'set datetime()' above.
+        let d: string = String(event);
+        this.datetime = d.replace(/ *(([\w:]+ +){1,6})(.*)/, "$1GMT+0000 (UTC)");
+        // let d: Date = new Date(String(event));
+        // // date defaults to local time zone.  The dates we choose are UTC so do the convert.
+        // let dateInStr: string = d.toString();
+        // // format of date string is ' Mon Sep 28 1998 14:36:22 GMT-0700 (PDT)'
+        // console.debug(`dateString is ${dateInStr}`);
+        // // dateInStr = dateInStr.replace(/ *(([\w:]+ +){1,6})(.*)/, "$1GMT+0 (UTC)");
+        // console.debug(`dateString after replace is ${dateInStr}`);
+        // // let dateUTC: Date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDay(), d.getHours(), d.getMinutes(), d.getSeconds()));
+        // this.datetime = MiscUtils.formatDateToDatetimeString(d);
+        // // No what I've done doesnt work - you can't force a TZ - it is always
+        // console.debug(`updateDate to str: ${dateInStr}, date: ${d} - dateTime is now: ${this.datetime}`);
     }
 
     /**
@@ -335,6 +327,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
      }
      }*/
 
+    // TODO - can't get time working properly until sort out TimeZones
     public getHours(): number {
         let d: Date = new Date(this.datetime);
         return d.getHours();
@@ -515,35 +508,6 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         }
     }
 
-    // private getFormatDateToDatetimeString(date: Date): string {
-    //     console.debug(`getFormatDateToDatetimeString - date ${date} typeof date: [${typeof date}] date valid: ${this.isaDate(date)} and getFullYear(): ${date.getFullYear()}`);
-    //     let dateStr: string = date.getFullYear() + '-'
-    //         + this.padTwo(date.getMonth() + 1) + '-'
-    //         + this.padTwo(date.getDate());
-    //     // let dateStr: string = date.getFullYear() + '-'
-    //     //         + date.getMonth() + '-'
-    //     //         + date.getDate();
-    //     // let newDate: Date = new Date(date.getTime());
-    //     // let newDate: Date = new Date();
-    //     // let newDate: Date = date;
-    //     // let dateStr: string = newDate.getFullYear() + '-' + (newDate.getMonth()+1) + '-' + newDate.getDate();
-    //     let timeStr: string = this.padTwo(date.getHours()) + ':'
-    //         + this.padTwo(date.getMinutes()) + ':'
-    //         + this.padTwo(date.getSeconds());
-    //
-    //     let dateTime: string = dateStr + 'T' + timeStr + defaultTZms;
-    //     let test: string = '2007-6-24';//T00:00:00';//.000Z';
-    //     // return
-    //     console.debug(`  getFormatDateToDatetimeString - should return '${dateTime}'`);
-    //     console.debug(`  getFormatDateToDatetimeString - but wl return '${test}'`);
-    //     console.debug(`  getFormatDateToDatetimeString - NOPE returning it`);
-    //     return dateTime;
-    //     // return test;
-    //
-    //     // this.datetimeDisplay = dateStr + ' ' + timeStr;
-    //     // this.datetimeLast = this.datetime;
-    //     // this.datetime = dateStr + 'T' + timeStr + defaultTZms;
-    // }
     /**
      * Emit a string in format of 'YYYY-MM-DDThh:mm:ss.sssZ' back to the input JSON object.
      */
@@ -563,35 +527,6 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     //     this.datetimeLast = this.datetime;
     //     this.datetime = dateStr + 'T' + timeStr + defaultTZms;
     // }
-
-    /**
-     * Returns an integer between min and max values by parsing from input str,
-     * return null if it is not a number or out of range.
-     */
-    private toInteger(str: string, min: number, max: number): number {
-        try {
-            let num: number = parseInt(str, 10);
-            if (isNaN(num)) {
-                return null;
-            } else if (num < min || num > max) {
-                return null;
-            } else {
-                return num;
-            }
-        } catch(error) {
-            return null;
-        }
-    }
-
-    /**
-     * Convert an integer to a two-character string.
-     */
-    private padTwo(index: number): string {
-        if (index < 10) {
-            return '0' + index.toString();
-        }
-        return index.toString();
-    }
 
     private checkPreConditions() {
         if (!this.controlName || this.controlName.length === 0) {

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -448,6 +448,9 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         return this.required || (this.requiredIfNotCurrent && this.index[0] !== 0);
     }
 
+    public closeDatetime() {
+        this.showDatetimePicker = false;
+    }
     /**
      * Update hour/minute/second time strings in response to any changes in hours, minutes, and seconds.
      */

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -92,6 +92,10 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
 
     public miscUtils: any = MiscUtils;
 
+    isFormDisabled(): boolean {
+        return this.form.disabled;
+    }
+
     // private _datetimeDisplay: string = '';
     // private _datetimeDisplayLast: string = '';
     // private hours: number = 0;

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -174,14 +174,14 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     set datetime(dt: string) {
         if (dt !== this._datetime) {
             // The datePicker sets its ngModel to formats like 'Sun 24th may 2016' or the like.  Convert.
-            let d: Date = new Date(dt);
+            // let d: Date = new Date(dt);
             // d.setTime(dt);
-            let d2: string = this.getFormatDateToDatetimeString(d);
+            let dateString: string = MiscUtils.formatDateToDatetimeString(new Date(dt));
             // let d2: string = '2000-08-23T00:00:00.000Z';
             // this._datetimeLast = dt;    //this._datetime;
-            this._datetime = d2;
-            this._datetimeDate = d;
-            console.debug(`${this.controlName} - set datetime - set to ${d2}, _datetimeDate is ${this._datetimeDate} - _datetimeLast is ${this._datetimeLast}`)
+            this._datetime = dateString;
+            // this._datetimeDate = d;
+            console.debug(`${this.controlName} - set datetime - set to ${dateString}, _datetimeDate is ${this._datetimeDate} - _datetimeLast is ${this._datetimeLast}`)
             // this._datetimeDisplay = DatetimeInputComponent.formatTimeToDisplay(dt);
             // this.datetimeModel = new Date();
             this.propagateChange(this._datetime);
@@ -282,7 +282,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
      */
     public updateDate(event: any): void {
         let d: Date = new Date(String(event));
-        this.datetime = this.getFormatDateToDatetimeString(d);  // String(event);  //
+        this.datetime = MiscUtils.formatDateToDatetimeString(d);
         console.debug(`updateDate to ${d} - dateTime is now: ${this.datetime}`);
     }
 
@@ -360,7 +360,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             hours = 23;
         }
         d.setHours(hours);
-        this.datetime = this.getFormatDateToDatetimeString(d);
+        this.datetime = MiscUtils.formatDateToDatetimeString(d);
         console.debug(`incrementHours to ${d} - dateTime is now: ${this.datetime}`);
     }
 
@@ -374,7 +374,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             hours = 23;
         }
         d.setHours(hours);
-        this.datetime = this.getFormatDateToDatetimeString(d);
+        this.datetime = MiscUtils.formatDateToDatetimeString(d);
         console.debug(`incrementHours to ${d} - dateTime is now: ${this.datetime}`);
     }
 
@@ -515,35 +515,35 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         }
     }
 
-    private getFormatDateToDatetimeString(date: Date): string {
-        console.debug(`getFormatDateToDatetimeString - date ${date} typeof date: [${typeof date}] date valid: ${this.isaDate(date)} and getFullYear(): ${date.getFullYear()}`);
-        let dateStr: string = date.getFullYear() + '-'
-            + this.padTwo(date.getMonth() + 1) + '-'
-            + this.padTwo(date.getDate());
-        // let dateStr: string = date.getFullYear() + '-'
-        //         + date.getMonth() + '-'
-        //         + date.getDate();
-        // let newDate: Date = new Date(date.getTime());
-        // let newDate: Date = new Date();
-        // let newDate: Date = date;
-        // let dateStr: string = newDate.getFullYear() + '-' + (newDate.getMonth()+1) + '-' + newDate.getDate();
-        let timeStr: string = this.padTwo(date.getHours()) + ':'
-            + this.padTwo(date.getMinutes()) + ':'
-            + this.padTwo(date.getSeconds());
-
-        let dateTime: string = dateStr + 'T' + timeStr + defaultTZms;
-        let test: string = '2007-6-24';//T00:00:00';//.000Z';
-        // return
-        console.debug(`  getFormatDateToDatetimeString - should return '${dateTime}'`);
-        console.debug(`  getFormatDateToDatetimeString - but wl return '${test}'`);
-        console.debug(`  getFormatDateToDatetimeString - NOPE returning it`);
-        return dateTime;
-        // return test;
-
-        // this.datetimeDisplay = dateStr + ' ' + timeStr;
-        // this.datetimeLast = this.datetime;
-        // this.datetime = dateStr + 'T' + timeStr + defaultTZms;
-    }
+    // private getFormatDateToDatetimeString(date: Date): string {
+    //     console.debug(`getFormatDateToDatetimeString - date ${date} typeof date: [${typeof date}] date valid: ${this.isaDate(date)} and getFullYear(): ${date.getFullYear()}`);
+    //     let dateStr: string = date.getFullYear() + '-'
+    //         + this.padTwo(date.getMonth() + 1) + '-'
+    //         + this.padTwo(date.getDate());
+    //     // let dateStr: string = date.getFullYear() + '-'
+    //     //         + date.getMonth() + '-'
+    //     //         + date.getDate();
+    //     // let newDate: Date = new Date(date.getTime());
+    //     // let newDate: Date = new Date();
+    //     // let newDate: Date = date;
+    //     // let dateStr: string = newDate.getFullYear() + '-' + (newDate.getMonth()+1) + '-' + newDate.getDate();
+    //     let timeStr: string = this.padTwo(date.getHours()) + ':'
+    //         + this.padTwo(date.getMinutes()) + ':'
+    //         + this.padTwo(date.getSeconds());
+    //
+    //     let dateTime: string = dateStr + 'T' + timeStr + defaultTZms;
+    //     let test: string = '2007-6-24';//T00:00:00';//.000Z';
+    //     // return
+    //     console.debug(`  getFormatDateToDatetimeString - should return '${dateTime}'`);
+    //     console.debug(`  getFormatDateToDatetimeString - but wl return '${test}'`);
+    //     console.debug(`  getFormatDateToDatetimeString - NOPE returning it`);
+    //     return dateTime;
+    //     // return test;
+    //
+    //     // this.datetimeDisplay = dateStr + ' ' + timeStr;
+    //     // this.datetimeLast = this.datetime;
+    //     // this.datetime = dateStr + 'T' + timeStr + defaultTZms;
+    // }
     /**
      * Emit a string in format of 'YYYY-MM-DDThh:mm:ss.sssZ' back to the input JSON object.
      */

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -1,5 +1,4 @@
-import { Component, ElementRef, HostListener, Input, OnInit, DoCheck, forwardRef, SimpleChange, OnChanges,
-    ChangeDetectorRef} from '@angular/core';
+import { Component, ElementRef, HostListener, Input, OnInit, forwardRef } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, NG_VALIDATORS, FormControl, FormGroup } from '@angular/forms';
 import { AbstractGnssControls } from './abstract-gnss-controls';
 import { MiscUtils } from '../index';
@@ -63,7 +62,7 @@ export function createDateTimeRequiredIfNotCurrentValidator(index: number) {
         // { provide: NG_VALIDATORS, useValue: dateTimeValidator, multi: true }
     ]
 })
-export class DatetimeInputComponent extends AbstractGnssControls implements OnInit, DoCheck, ControlValueAccessor, OnChanges {
+export class DatetimeInputComponent extends AbstractGnssControls implements OnInit, ControlValueAccessor {
     @Input() name: string = 'Date';
     @Input() required: boolean = false;
     @Input() requiredIfNotCurrent: boolean = false;
@@ -99,73 +98,33 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     public propagateTouch: Function = () => { };
     public validateFn: Function = () => { };
 
-    constructor(private elemRef: ElementRef, private changeDetectionRef : ChangeDetectorRef) {
+    constructor(private elemRef: ElementRef) {
         super();
-        // this._datetimeDate = new Date();
     }
 
     ngOnInit() {
         this.checkPreConditions();
         this.createValidators();
         super.setForm(this.form);
-        // this._datetimeDate = new Date();
     }
 
     validate(c: FormControl): any {
         return this.validateFn(c);
     }
 
-    ngDoCheck(): void {
-        // If the @Input is changed externally, want to update the displayed date
-        // if (null && this.datetimeLast !== this.datetime) {
-        //     console.debug(`${this.controlName} - ngDoCheck - update this.datetimeLast (was ${this.datetimeLast}) to ${this.datetime}`)
-        //     this.datetimeLast = this.datetime;
-        // }
-    }
-
-    ngOnChanges(changes: {[propKey: string]: SimpleChange}) {
-        let log: string[] = [];
-        for (let propName in changes) {
-            let changedProp = changes[propName];
-            console.debug(`ngOnChanges - prop: ${propName}, value: ${changedProp.currentValue}`)
-            // if (changedProp.isFirstChange()) {
-            // if (propName === 'geodesyEvent') {
-            //     this.handleGeodesyEvents();
-            // }
-            // }
-        }
-    }
-    // set datetimeDisplay(dt: string) {
-    //     if (null && dt !== this._datetimeDisplayLast) {
-    //         this._datetimeDisplayLast = this._datetimeDisplay;
-    //         this._datetimeDisplay = dt;
-    //         this._datetime = this.formatDisplayToTime(dt);
-    //         this.propagateChange(this._datetime);
-    //     }
-    // }
-    //
-    // get datetimeDisplay() {
-    //     return this._datetimeDisplay;
-    // }
-
     // TODO - needs fixing to handle TimeZones
     set datetime(dt: string) {
         if (dt !== this._datetime) {
-            // The datePicker sets its ngModel to formats like 'Sun 24th may 2016' or the like.  Convert.
+            // The datePicker sets its ngModel to formats like 'Sun 24th may 2016'.  Convert.
             // let d: Date = new Date(dt);
             // d.setTime(dt);
             let dateString: string = MiscUtils.formatDateToDatetimeString(new Date(dt));
-            // let d2: string = '2000-08-23T00:00:00.000Z';
+            // let d2: string = '2000-08-23T00:00:00' + defaultTZms;
             // this._datetimeLast = dt;    //this._datetime;
             this._datetime = dateString;
-            // this._datetimeDate = d;
             console.debug(`${this.controlName} - set datetime - set to ${dateString} from ${dt} string`)
-            // this._datetimeDisplay = DatetimeInputComponent.formatTimeToDisplay(dt);
-            // this.datetimeModel = new Date();
             this.propagateChange(this._datetime);
-            // this.form.markAsTouched();//markAsTouched();// patchValue({controlName: this._datetime});
             // this.updateCalendar();
-            // console.debug(`${this.controlName} - END set datetime - set to ${dt} - _datetimeLast is ${this._datetimeLast}`)
         } else {
             console.debug(`${this.controlName} - set datetime - not setting as same`);
         }
@@ -173,19 +132,13 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     }
 
     get datetime(): string {
-        // console.debug(`${this.controlName} - get dateTime: ${this._datetime}`);
         return this._datetime;
     }
 
-    /**
-     * Initialize relevant variables when the directive is instantiated
-     */
-
-    /* Methods for Model-based forms - implement ControlValueAccessor */
+    /* ControlValueAccessor Methods */
 
     writeValue(value: string) {
         if (value) {
-            // console.debug(`${this.controlName} - writeValue ${value} - _datetime is ${this._datetime}`)
             this.datetime = value;
         }
     }
@@ -231,6 +184,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         }
     }
 
+    // TODO - put these back in place.  Currently the buttons just close the dialog.
     /**
      * Set the selected datetime value to the datetime model when users click on the OK button
      */
@@ -255,6 +209,10 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     //     this.showDatetimePicker = false;
     // }
 
+    public closeDatetime() {
+        this.showDatetimePicker = false;
+    }
+
     /**
      * Update the datetime model when users select a date on calendar
      */
@@ -277,55 +235,6 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         // // No what I've done doesnt work - you can't force a TZ - it is always
         // console.debug(`updateDate to str: ${dateInStr}, date: ${d} - dateTime is now: ${this.datetime}`);
     }
-
-    /**
-     * Update the calendar and datetime model in response to direct changes made in the input box
-     */
-    /*    public updateCalendar(): void {
-     let newDate: Date = this.convertStringToDate(this.datetimeDisplay);
-     if (newDate === null) {
-     this.datetimeModel = new Date();
-     } else {
-     this.datetimeModel = newDate;
-     }
-     this.hours = this.datetimeModel.getHours();
-     this.minutes = this.datetimeModel.getMinutes();
-     this.seconds = this.datetimeModel.getSeconds();
-     this.updateTimeStrings();
-     }
-
-     public updateHours(): void {
-     this.hours = this.toInteger(this.hoursString, 0, 23);
-     if (this.hours === null) {
-     this.invalidHours = true;
-     this.hours = 0;
-     } else {
-     this.invalidHours = false;
-     this.updateTimeStrings();
-     }
-     }
-
-     public updateMinutes(): void {
-     this.minutes = this.toInteger(this.minutesString, 0, 59);
-     if (this.minutes === null) {
-     this.invalidMinutes = true;
-     this.minutes = 0;
-     } else {
-     this.invalidMinutes = false;
-     this.updateTimeStrings();
-     }
-     }
-
-     public updateSeconds(): void {
-     this.seconds = this.toInteger(this.secondsString, 0, 59);
-     if (this.seconds === null) {
-     this.invalidSeconds = true;
-     this.seconds = 0;
-     } else {
-     this.invalidSeconds = false;
-     this.updateTimeStrings();
-     }
-     }*/
 
     // TODO - can't get time working properly until sort out TimeZones
     public getHours(): number {
@@ -371,165 +280,9 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         console.debug(`incrementHours to ${d} - dateTime is now: ${this.datetime}`);
     }
 
-    /*       this.hours += 1;
-     if (this.hours > 23) {
-     this.hours = 0;
-     } else if (this.hours < 0) {
-     this.hours = 23;
-     }
-     this.invalidHours = false;
-     this.updateTimeStrings();
-     }
-
-     public decrementHours(): void {
-     this.hours -= 1;
-     if (this.hours > 23) {
-     this.hours = 0;
-     } else if (this.hours < 0) {
-     this.hours = 23;
-     }
-     this.invalidHours = false;
-     this.updateTimeStrings();
-     }
-
-     public incrementMinutes(): void {
-     this.minutes += 1;
-     if (this.minutes > 59) {
-     this.minutes = 0;
-     this.incrementHours();
-     } else if (this.minutes < 0) {
-     this.minutes = 59;
-     this.decrementHours();
-     }
-     this.invalidMinutes = false;
-     this.updateTimeStrings();
-     }
-
-     public decrementMinutes(): void {
-     this.minutes -= 1;
-     if (this.minutes > 59) {
-     this.minutes = 0;
-     this.incrementHours();
-     } else if (this.minutes < 0) {
-     this.minutes = 59;
-     this.decrementHours();
-     }
-     this.invalidMinutes = false;
-     this.updateTimeStrings();
-     }
-
-     public incrementSeconds(): void {
-     this.seconds += 1;
-     if (this.seconds > 59) {
-     this.seconds = 0;
-     this.incrementMinutes();
-     } else if (this.seconds < 0) {
-     this.seconds = 59;
-     this.decrementMinutes();
-     }
-     this.invalidSeconds = false;
-     this.updateTimeStrings();
-     }
-
-     public decrementSeconds(): void {
-     this.seconds -= 1;
-     if (this.seconds > 59) {
-     this.seconds = 0;
-     this.incrementMinutes();
-     } else if (this.seconds < 0) {
-     this.seconds = 59;
-     this.decrementMinutes();
-     }
-     this.invalidSeconds = false;
-     this.updateTimeStrings();
-     }*/
-
     public isRequired() : boolean {
         return this.required || (this.requiredIfNotCurrent && this.index[0] !== 0);
     }
-
-    public closeDatetime() {
-        this.showDatetimePicker = false;
-    }
-    /**
-     * Update hour/minute/second time strings in response to any changes in hours, minutes, and seconds.
-     */
-    // private updateTimeStrings() {
-    //     this.hoursString = this.padTwo(this.hours);
-    //     this.minutesString = this.padTwo(this.minutes);
-    //     this.secondsString = this.padTwo(this.seconds);
-    // }
-
-    /**
-     * Convert a string in format of 'YYYY-MM-DDThh:mm:ss.sssZ' to a Date object.
-     */
-    // private convertStringToDate(dtStr: string): Date {
-    //     if (dtStr === null || dtStr.trim().length === 0) {
-    //         return null;
-    //     } else if (dtStr.trim().length < 19) {
-    //         return null;
-    //     }
-    //
-    //     try {
-    //         let date: Date = new Date(dtStr.substring(0, 19).replace(' ', 'T'));
-    //         if (date !== null && date.toString() !== 'Invalid Date') {
-    //             return date;
-    //         }
-    //     } catch(error) {
-    //         console.log('Error:'+error);
-    //     }
-    //
-    //     return null;
-    // }
-
-    // private formatDisplayToTime(displayStr: string): string {
-    //     let datetime = '';
-    //     if (displayStr !== null) {
-    //         datetime = displayStr.replace(' ', 'T');
-    //         if (displayStr.match(validDisplayFormat)) {
-    //             datetime += defaultTZms;
-    //         }
-    //     }
-    //     return datetime;
-    // }
-
-    private isaDate(date: Date): boolean {
-        if ( Object.prototype.toString.call(date) === "[object Date]" ) {
-            // it is a date
-            if ( isNaN( date.getTime() ) ) {  // d.valueOf() could also work
-                // date is not valid
-                return false;
-            }
-            else {
-                // date is valid
-                return true;
-            }
-        }
-        else {
-            // not a date
-            return false;
-        }
-    }
-
-    /**
-     * Emit a string in format of 'YYYY-MM-DDThh:mm:ss.sssZ' back to the input JSON object.
-     */
-    // private emitOutputDatetime(): void {
-    //     if (this.datetimeModel === null) {
-    //         return;
-    //     }
-    //
-    //     let dateStr: string = this.datetimeModel.getFullYear() + '-'
-    //         + this.padTwo(this.datetimeModel.getMonth() + 1) + '-'
-    //         + this.padTwo(this.datetimeModel.getDate());
-    //     let timeStr: string = this.padTwo(this.datetimeModel.getHours()) + ':'
-    //         + this.padTwo(this.datetimeModel.getMinutes()) + ':'
-    //         + this.padTwo(this.datetimeModel.getSeconds());
-    //
-    //     this.datetimeDisplay = dateStr + ' ' + timeStr;
-    //     this.datetimeLast = this.datetime;
-    //     this.datetime = dateStr + 'T' + timeStr + defaultTZms;
-    // }
 
     private checkPreConditions() {
         if (!this.controlName || this.controlName.length === 0) {

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -77,10 +77,6 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
 
     public miscUtils: any = MiscUtils;
 
-    isFormDisabled(): boolean {
-        return this.form.disabled;
-    }
-
     static formatTimeToDisplay(dateStr: string, returnAsIsUponFailure: boolean = false): string {
         let datetimeDisplay: string = '';
         if (dateStr !== null) {
@@ -102,6 +98,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         super();
     }
 
+
     ngOnInit() {
         this.checkPreConditions();
         this.createValidators();
@@ -122,7 +119,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             // let d2: string = '2000-08-23T00:00:00' + defaultTZms;
             // this._datetimeLast = dt;    //this._datetime;
             this._datetime = dateString;
-            console.debug(`${this.controlName} - set datetime - set to ${dateString} from ${dt} string`)
+            console.debug(`${this.controlName} - set datetime - set to ${dateString} from ${dt} string`);
             this.propagateChange(this._datetime);
             // this.updateCalendar();
         } else {
@@ -184,6 +181,10 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         }
     }
 
+    public isFormDisabled(): boolean {
+        return this.form.disabled;
+    }
+
     // TODO - put these back in place.  Currently the buttons just close the dialog.
     /**
      * Set the selected datetime value to the datetime model when users click on the OK button
@@ -222,15 +223,15 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         // TODO - To prevent TZ problem use something like moment and moment-timezone
         // TODO - Also see 'set datetime()' above.
         let d: string = String(event);
-        this.datetime = d.replace(/ *(([\w:]+ +){1,6})(.*)/, "$1GMT+0000 (UTC)");
+        this.datetime = d.replace(/ *(([\w:]+ +){1,6})(.*)/, '$1GMT+0000 (UTC)');
         // let d: Date = new Date(String(event));
         // // date defaults to local time zone.  The dates we choose are UTC so do the convert.
         // let dateInStr: string = d.toString();
         // // format of date string is ' Mon Sep 28 1998 14:36:22 GMT-0700 (PDT)'
         // console.debug(`dateString is ${dateInStr}`);
-        // // dateInStr = dateInStr.replace(/ *(([\w:]+ +){1,6})(.*)/, "$1GMT+0 (UTC)");
+        // // dateInStr = dateInStr.replace(/ *(([\w:]+ +){1,6})(.*)/, '$1GMT+0 (UTC)');
         // console.debug(`dateString after replace is ${dateInStr}`);
-        // // let dateUTC: Date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDay(), d.getHours(), d.getMinutes(), d.getSeconds()));
+        // let dateUTC: Date = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDay(), d.getHours(), d.getMinutes(), d.getSeconds()));
         // this.datetime = MiscUtils.formatDateToDatetimeString(d);
         // // No what I've done doesnt work - you can't force a TZ - it is always
         // console.debug(`updateDate to str: ${dateInStr}, date: ${d} - dateTime is now: ${this.datetime}`);

--- a/src/client/app/shared/global/json-diff.service.spec.ts
+++ b/src/client/app/shared/global/json-diff.service.spec.ts
@@ -645,14 +645,14 @@ export function main() {
     it('test getIdentifier()', () => {
       let ident = jsonDiffService.getIdentifier(jsonDiffService.getObject(humiditySensor_1Sensors, '/humiditySensors/0/humiditySensor'));
       expect(ident).toBeDefined();
-      expect(ident).toEqual(MiscUtils.getDate('2016-10-01T00:00:00.000Z'));
+      expect(ident).toEqual(MiscUtils.getDateComponent('2016-10-01T00:00:00.000Z'));
     });
 
     it('test getIdentifier() 2', () => {
       let ident = jsonDiffService.getIdentifier(jsonDiffService.getObject(humiditySensor_2Sensors, '/humiditySensors/0/humiditySensor'));
       expect(ident).toBeDefined();
-      expect(ident).toEqual(MiscUtils.getDate('2016-10-01T00:00:00.000Z') + ' &ndash; ' +
-        MiscUtils.getDate('2016-10-31T00:00:00.000Z'));
+      expect(ident).toEqual(MiscUtils.getDateComponent('2016-10-01T00:00:00.000Z') + ' &ndash; ' +
+        MiscUtils.getDateComponent('2016-10-31T00:00:00.000Z'));
     });
 
     it('test humidity sensor intermediate diff - Edit manufacturer', () => {
@@ -666,7 +666,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-15T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-15T00:00:00.000Z'));
       expect(diffItem.item).toEqual('manufacturer');
       expect(diffItem.oldValue).toEqual('Vaisala1');
       expect(diffItem.newValue).toEqual('Vaisala1 new');
@@ -684,7 +684,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-16T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-16T00:00:00.000Z'));
       expect(diffItem.item).toEqual('startDate');
       expect(diffItem.oldValue).toEqual('2016-11-15T00:00:00.000Z');
       expect(diffItem.newValue).toEqual('2016-11-16T00:00:00.000Z');
@@ -702,7 +702,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-16T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-16T00:00:00.000Z'));
       expect(diffItem.item).toEqual('startDate');
       expect(diffItem.oldValue).toEqual('2016-11-15T00:00:00.000Z');
       expect(diffItem.newValue).toEqual('2016-11-16T00:00:00.000Z');
@@ -711,7 +711,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-16T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-16T00:00:00.000Z'));
       expect(diffItem.item).toEqual('manufacturer');
       expect(diffItem.oldValue).toEqual('Vaisala1');
       expect(diffItem.newValue).toEqual('Vaisala1 new');
@@ -729,8 +729,8 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.New);
       expect(diffItem.container).toEqual('gnssReceivers');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
-        MiscUtils.getDate('1998-09-17T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
+        MiscUtils.getDateComponent('1998-09-17T00:00:00.000Z'));
       expect(diffItem.item).toEqual('newField');
       expect(diffItem.oldValue).toEqual('');
       expect(diffItem.newValue).toEqual('newFieldValue');
@@ -748,8 +748,8 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Deleted);
       expect(diffItem.container).toEqual('gnssReceivers');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
-        MiscUtils.getDate('1998-09-17T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
+        MiscUtils.getDateComponent('1998-09-17T00:00:00.000Z'));
       expect(diffItem.item).toEqual('notes');
       expect(diffItem.oldValue).toEqual('Receiver 1');
       expect(diffItem.newValue).toEqual('');
@@ -767,8 +767,8 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.New);
       expect(diffItem.container).toEqual('gnssReceivers');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
-        MiscUtils.getDate('1998-09-17T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
+        MiscUtils.getDateComponent('1998-09-17T00:00:00.000Z'));
       expect(diffItem.item).toEqual('newField');
       expect(diffItem.oldValue).toEqual('');
       expect(diffItem.newValue).toEqual('newFieldValue');
@@ -777,8 +777,8 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Deleted);
       expect(diffItem.container).toEqual('gnssReceivers');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
-        MiscUtils.getDate('1998-09-17T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('1996-01-01T00:00:00.000Z') + ' &ndash; ' +
+        MiscUtils.getDateComponent('1998-09-17T00:00:00.000Z'));
       expect(diffItem.item).toEqual('notes');
       expect(diffItem.oldValue).toEqual('Receiver 1');
       expect(diffItem.newValue).toEqual('');
@@ -811,7 +811,7 @@ export function main() {
       expect(diffItem.oldValue).toEqual('');
       expect(diffItem.newValue).toBeDefined();
       let humiditySensor: HumiditySensorViewModel = <HumiditySensorViewModel> diffItem.newValue.humiditySensor;
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
       console.log('humiditySensor new item:', humiditySensor);
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 2');
       expect(humiditySensor.serialNumber).toEqual('P2240006 2');
@@ -847,7 +847,7 @@ export function main() {
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 2');
       expect(humiditySensor.serialNumber).toEqual('P2240006 2');
       expect(humiditySensor.dateInserted).toEqual(date1);
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
 
       diffItem = intDiffs[2];
       expect(diffItem.diffType).toEqual(DiffType.NewArrayItem);
@@ -860,7 +860,7 @@ export function main() {
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 3');
       expect(humiditySensor.serialNumber).toEqual('P2240006 3');
       expect(humiditySensor.dateInserted).toEqual(date2);
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
     });
 
     it('arrays test humidity sensor - were 3 remove 3rd', () => {
@@ -929,7 +929,7 @@ export function main() {
 
       let identifier: string = nd[0];
       expect(identifier).toContain(
-        MiscUtils.getDate(humiditySensor_new_manufacturer.humiditySensors[0].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_new_manufacturer.humiditySensors[0].humiditySensor.startDate));
 
       let diffItems: DiffItem[] = nd[1];
       expect(diffItems.length).toEqual(1);
@@ -938,7 +938,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-15T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-15T00:00:00.000Z'));
       expect(diffItem.item).toEqual('manufacturer');
       expect(diffItem.oldValue).toEqual('Vaisala1');
       expect(diffItem.newValue).toEqual('Vaisala1 new');
@@ -961,14 +961,14 @@ export function main() {
       let diffItems: DiffItem[] = nd[1];
 
       expect(identifier).toContain(
-        MiscUtils.getDate(humiditySensor_new_manufacturer_date.humiditySensors[0].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_new_manufacturer_date.humiditySensors[0].humiditySensor.startDate));
 
       expect(diffItems.length).toEqual(2);
       let diffItem: DiffItem = diffItems[1];
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-16T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-16T00:00:00.000Z'));
       expect(diffItem.item).toEqual('startDate');
       expect(diffItem.oldValue).toEqual('2016-11-15T00:00:00.000Z');
       expect(diffItem.newValue).toEqual('2016-11-16T00:00:00.000Z');
@@ -977,7 +977,7 @@ export function main() {
 
       expect(diffItem.diffType).toEqual(DiffType.Edited);
       expect(diffItem.container).toEqual('humiditySensors');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate('2016-11-16T00:00:00.000Z'));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent('2016-11-16T00:00:00.000Z'));
       expect(diffItem.item).toEqual('manufacturer');
       expect(diffItem.oldValue).toEqual('Vaisala1');
       expect(diffItem.newValue).toEqual('Vaisala1 new');
@@ -1008,8 +1008,8 @@ export function main() {
       // mapKey looks something like 'container => identifier' eg. 'HumiditySensors=>2016-12-01..._to_2016-12-31...'
       console.log('mapKey: ', mapKey);
       expect(mapKey).toContain('humiditySensor');
-      expect(mapKey).toContain(MiscUtils.getDate(humiditySensor_2Sensors.humiditySensors[0].humiditySensor.startDate));
-      expect(mapKey).toContain(MiscUtils.getDate(humiditySensor_2Sensors.humiditySensors[0].humiditySensor.endDate));
+      expect(mapKey).toContain(MiscUtils.getDateComponent(humiditySensor_2Sensors.humiditySensors[0].humiditySensor.startDate));
+      expect(mapKey).toContain(MiscUtils.getDateComponent(humiditySensor_2Sensors.humiditySensors[0].humiditySensor.endDate));
 
       expect(diffItems.length).toEqual(1);
       diffItem = diffItems[0];
@@ -1052,7 +1052,7 @@ export function main() {
       console.log('humiditySensor new item:', humiditySensor);
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 2');
       expect(humiditySensor.serialNumber).toEqual('P2240006 2');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
     });
 
     it('normalised test humidity sensor 1 add 2nd, 3rd', () => {
@@ -1085,8 +1085,8 @@ export function main() {
       // mapKey looks something like 'container => identifier' eg. 'HumiditySensors=>2016-12-01..._to_2016-12-31...'
       console.log('mapKey: ', mapKey);
       expect(mapKey).toContain('humiditySensor');
-      expect(mapKey).toContain(MiscUtils.getDate(humiditySensor_3Sensors.humiditySensors[0].humiditySensor.startDate));
-      expect(mapKey).toContain(MiscUtils.getDate(humiditySensor_3Sensors.humiditySensors[0].humiditySensor.endDate));
+      expect(mapKey).toContain(MiscUtils.getDateComponent(humiditySensor_3Sensors.humiditySensors[0].humiditySensor.startDate));
+      expect(mapKey).toContain(MiscUtils.getDateComponent(humiditySensor_3Sensors.humiditySensors[0].humiditySensor.endDate));
 
       expect(diffItems.length).toEqual(1);
       diffItem = diffItems[0];
@@ -1129,7 +1129,7 @@ export function main() {
       console.log('humiditySensor new item:', humiditySensor);
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 2');
       expect(humiditySensor.serialNumber).toEqual('P2240006 2');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
 
       /* ******************** 3 ************************** */
       nextContainerDiff = diffEntries.next();
@@ -1160,7 +1160,7 @@ export function main() {
       console.log('humiditySensor new item:', humiditySensor);
       expect(humiditySensor.manufacturer).toEqual('Vaisala1 3');
       expect(humiditySensor.serialNumber).toEqual('P2240006 3');
-      expect(diffItem.identifier).toEqual(MiscUtils.getDate(humiditySensor.startDate));
+      expect(diffItem.identifier).toEqual(MiscUtils.getDateComponent(humiditySensor.startDate));
     });
 
     it('normalised test humidity sensor - were 3 remove 2nd, 3rd', () => {
@@ -1196,9 +1196,9 @@ export function main() {
       console.log('mapKey: ', mapKey);
       expect(mapKey).toContain('humiditySensor');
       expect(mapKey).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.startDate));
       expect(mapKey).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.endDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.endDate));
 
       expect(diffItems.length).toEqual(1);
       diffItem = diffItems[0];
@@ -1212,9 +1212,9 @@ export function main() {
       expect(diffItem.item).toEqual('dateDeleted');
       expect(diffItem.container).toEqual('humiditySensors');
       expect(diffItem.identifier).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.startDate));
       expect(diffItem.identifier).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.endDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[1].humiditySensor.endDate));
       expect(diffItem.oldValue).toEqual('');
       expect(diffItem.newValue).toEqual(date1);
 
@@ -1228,9 +1228,9 @@ export function main() {
       console.log('mapKey: ', mapKey);
       expect(mapKey).toContain('humiditySensor');
       expect(mapKey).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.startDate));
       expect(mapKey).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.endDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.endDate));
 
       expect(diffItems.length).toEqual(1);
       diffItem = diffItems[0];
@@ -1245,9 +1245,9 @@ export function main() {
       expect(diffItem.item).toEqual('dateDeleted');
       expect(diffItem.container).toEqual('humiditySensors');
       expect(diffItem.identifier).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.startDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.startDate));
       expect(diffItem.identifier).toContain(
-        MiscUtils.getDate(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.endDate));
+        MiscUtils.getDateComponent(humiditySensor_3Sensors_Remove2nd3rd.humiditySensors[2].humiditySensor.endDate));
       expect(diffItem.oldValue).toEqual('');
       expect(diffItem.newValue).toEqual(date2);
     });

--- a/src/client/app/shared/global/json-diff.service.ts
+++ b/src/client/app/shared/global/json-diff.service.ts
@@ -369,9 +369,9 @@ export class JsonDiffService {
             return '';
         }
         if (object.startDate && this.isString(object.startDate)) {
-            ident += MiscUtils.getDate(object.startDate);
+            ident += MiscUtils.getDateComponent(object.startDate);
             if (object.endDate && this.isString(object.endDate)) {
-                ident += ' &ndash; ' + MiscUtils.getDate(object.endDate);
+                ident += ' &ndash; ' + MiscUtils.getDateComponent(object.endDate);
             }
         }
         return ident;

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -33,6 +33,50 @@ export class MiscUtils {
     }
 
     /**
+     * Return a date as a string in the "YYYY-MM-DD'T'hh:mm:ss.000Z" format.
+     *
+     * @param date
+     * @return {string}
+     */
+    public static formatDateToDatetimeString(date: Date|string): string {
+        // If already a string return as-is
+        if (typeof date === 'string') {
+            return date;
+        }
+        if (! MiscUtils.isDate(date)) {
+            throw new Error(`Input isnt a date - type: ${typeof date}, value: ${date}`);
+        }
+        let dateStr: string = date.getFullYear() + '-'
+            + MiscUtils.padTwo(date.getMonth() + 1) + '-'
+            + MiscUtils.padTwo(date.getDate());
+        let timeStr: string = this.padTwo(date.getHours()) + ':'
+            + MiscUtils.padTwo(date.getMinutes()) + ':'
+            + MiscUtils.padTwo(date.getSeconds());
+
+        let dateTime: string = dateStr + 'T' + timeStr + '.000Z';
+
+        return dateTime;
+    }
+
+    public static isDate(date: Date): boolean {
+        if (Object.prototype.toString.call(date) === "[object Date]") {
+            return ! isNaN(date.getTime());
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Convert an integer to a two-character string.
+     */
+    public static padTwo(index: number): string {
+        if (index < 10) {
+            return '0' + index.toString();
+        }
+        return index.toString();
+    }
+
+    /**
      * Clone a JSON object from existing one so that both have no reference
      */
     public static cloneJsonObj(obj: any): any {

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -23,7 +23,7 @@ export class MiscUtils {
     /**
      * Returns the date string (YYYY-MM-DD) from the date-time string (YYYY-MM-DDThh:mm:ssZ)
      */
-    public static getDate(datetime: string): string {
+    public static getDateComponent(datetime: string): string {
         if (datetime === null || typeof datetime === 'undefined') {
             return '';
         } else if (datetime.length < 10) {
@@ -32,23 +32,27 @@ export class MiscUtils {
         return datetime.substring(0, 10);
     }
 
-    /**
-     * Return a date as a string in the "YYYY-MM-DD'T'hh:mm:ss.000Z" format.
-     *
-     * @param date
-     * @return {string}
-     */
-    public static formatDateToDatetimeString(date: Date|string): string {
-        // If already a string return as-is
-        if (typeof date === 'string') {
-            return date;
-        }
+    public static formatDateToDateString(date: Date): string {
         if (! MiscUtils.isDate(date)) {
             throw new Error(`Input isnt a date - type: ${typeof date}, value: ${date}`);
         }
         let dateStr: string = date.getFullYear() + '-'
             + MiscUtils.padTwo(date.getMonth() + 1) + '-'
             + MiscUtils.padTwo(date.getDate());
+        return dateStr;
+    }
+    /**
+     * Return a date as a string in the "YYYY-MM-DD'T'hh:mm:ss.000Z" format.
+     *
+     * @param date
+     * @return {string}
+     */
+    public static formatDateToDatetimeString(date: Date): string {
+        if (! MiscUtils.isDate(date)) {
+            throw new Error(`Input isnt a date - type: ${typeof date}, value: ${date}`);
+        }
+        let dateStr: string = MiscUtils.formatDateToDateString(date);
+
         let timeStr: string = this.padTwo(date.getHours()) + ':'
             + MiscUtils.padTwo(date.getMinutes()) + ':'
             + MiscUtils.padTwo(date.getSeconds());

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -59,7 +59,7 @@ export class MiscUtils {
     }
 
     public static isDate(date: Date): boolean {
-        if (Object.prototype.toString.call(date) === "[object Date]") {
+        if (Object.prototype.toString.call(date) === '[object Date]') {
             return ! isNaN(date.getTime());
         } else {
             return false;

--- a/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
@@ -131,7 +131,7 @@ export function main() {
 
     // now test the new 'date' format type - that is only applied v2d
 
-      fit('should translate v2d for gnssReceivers using translate method and Date() dates', () => {
+      it('should translate v2d for gnssReceivers using translate method and Date() dates', () => {
           let receiverData: any = new SiteLogDataModel(completeValidSitelog).gnssReceivers;
           expect(receiverData).toBeDefined();
           let firstRD: any = receiverData[1];
@@ -161,7 +161,7 @@ export function main() {
           // dateInstalled was changed to a Date
           expect(newRD.gnssReceiver.dateInstalled.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.startDate));
           // But dateRemoved wasn't
-          expect(newRD.gnssReceiver.dateRemoved.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.endDate));
+          expect(newRD.gnssReceiver.dateRemoved.value[0]).toEqual(firstRV.endDate);
           // expect(firstRV.startDate).toEqual(newRD.gnssReceiver.validTime.abstractTimePrimitive['gml:TimePeriod']
           //     .beginPosition.value[0]);
           // expect(firstRV.endDate).toBeNull();

--- a/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.spec.ts
@@ -141,7 +141,7 @@ export function main() {
           DataViewTranslatorService.translateD2V(firstRD, firstRV, firstRV.getFieldMaps());
 
           // Now change the dateInstalled, removed to dates
-          firstRV.dateInstalled = new Date(firstRV.dateInstalled);
+          firstRV.startDate = new Date(firstRV.startDate);
 
           let newRD: any = {};
           // DataViewTranslatorService.translateV2D(firstHSV, newHSD, firstHSV.getFieldMaps());
@@ -159,9 +159,9 @@ export function main() {
           expect(newRD.gnssReceiver.temperatureStabilization).toEqual(firstRV.temperatureStabilization);
 
           // dateInstalled was changed to a Date
-          expect(newRD.gnssReceiver.dateInstalled.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.dateInstalled));
+          expect(newRD.gnssReceiver.dateInstalled.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.startDate));
           // But dateRemoved wasn't
-          expect(newRD.gnssReceiver.dateRemoved.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.dateRemoved));
+          expect(newRD.gnssReceiver.dateRemoved.value[0]).toEqual(MiscUtils.formatDateToDatetimeString(firstRV.endDate));
           // expect(firstRV.startDate).toEqual(newRD.gnssReceiver.validTime.abstractTimePrimitive['gml:TimePeriod']
           //     .beginPosition.value[0]);
           // expect(firstRV.endDate).toBeNull();

--- a/src/client/app/shared/json-data-view-model/data-view-translator.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.ts
@@ -79,12 +79,14 @@ export class DataViewTranslatorService {
               sourceTypedPointer = fieldMap.viewTypedPointer;
               targetTypedPointer = fieldMap.dataTypedPointer;
           }
-          let sourceValue: string = JsonPointerService.get(source, sourceTypedPointer.pointer);
+          let sourceValue: any = JsonPointerService.get(source, sourceTypedPointer.pointer);
           if (targetTypedPointer.type === 'number') {
               JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ? parseFloat(sourceValue) : null);
           } else if (sourceTypedPointer.type === 'date') {  // 'date' type will only be on the view side
-              JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ?
-                  MiscUtils.formatDateToDatetimeString(sourceValue) : null);
+              // Currently the dates can be string (from the database) or Date (as returned by DatePicker widget)
+              // Must handle both (eg. AbstractViewModel.startDate)
+              let dateValue: string = MiscUtils.isDate(sourceValue) ? MiscUtils.formatDateToDatetimeString(sourceValue) : sourceValue;
+              JsonPointerService.set(target, targetTypedPointer.pointer, dateValue !== null ? dateValue : null);
           } else {
               JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue);
           }

--- a/src/client/app/shared/json-data-view-model/data-view-translator.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.ts
@@ -1,5 +1,6 @@
 import { JsonPointerService } from '../json-pointer/json-pointer.service';
 import { AbstractViewModel } from './view-model/abstract-view-model';
+import { MiscUtils } from '../global/misc-utils';
 
 export const doWriteViewToData: boolean = true;
 
@@ -57,33 +58,36 @@ export class DataViewTranslatorService {
         DataViewTranslatorService.translate(viewModel, dataModel, fieldMappings, true);
     }
 
-    /**
-     * Generic translate independant of view and data models.  As long as the mappings are in the source, the data will be
-     * written into the mapped location in the target.
-     *
-     * @param source - source to read from - if writeViewToData is false then this is the data model else the view model
-     * @param target - target to write to - if writeViewToData is false then this is the view model else the data model
-     * @param writeViewToData - if false then write source data model to target view model (pass source, target appropriately);
-     *                        if true then write source view model to target data model (pass source, target appropriately);
-     */
-    static translate(source: any, target: any, fieldMappings: FieldMap[], writeViewToData: boolean = false) {
-        for (let fieldMap of fieldMappings) {
-            // View and Data references currently retained from original translate context
-            let sourceTypedPointer: TypedPointer;
-            let targetTypedPointer: TypedPointer;
-            if (!writeViewToData) {
-                sourceTypedPointer = fieldMap.dataTypedPointer;
-                targetTypedPointer = fieldMap.viewTypedPointer;
-            } else {
-                sourceTypedPointer = fieldMap.viewTypedPointer;
-                targetTypedPointer = fieldMap.dataTypedPointer;
-            }
-            let sourceValue: string = JsonPointerService.get(source, sourceTypedPointer.pointer);
-            if (targetTypedPointer.type === 'number') {
-                JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ? parseFloat(sourceValue) : null);
-            } else {
-                JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue);
-            }
-        }
-    }
+  /**
+   * Generic translate independant of view and data models.  As long as the mappings are in the source, the data will be
+   * written into the mapped location in the target.
+   *
+   * @param source - source to read from - if writeViewToData is false then this is the data model else the view model
+   * @param target - target to write to - if writeViewToData is false then this is the view model else the data model
+   * @param writeViewToData - if false then write source data model to target view model (pass source, target appropriately);
+   *                        if true then write source view model to target data model (pass source, target appropriately);
+   */
+  static translate(source: any, target: any, fieldMappings: FieldMap[], writeViewToData: boolean = false) {
+      for (let fieldMap of fieldMappings) {
+          // View and Data references currently retained from original translate context
+          let sourceTypedPointer: TypedPointer;
+          let targetTypedPointer: TypedPointer;
+          if (! writeViewToData) {
+              sourceTypedPointer = fieldMap.dataTypedPointer;
+              targetTypedPointer = fieldMap.viewTypedPointer;
+          } else {
+              sourceTypedPointer = fieldMap.viewTypedPointer;
+              targetTypedPointer = fieldMap.dataTypedPointer;
+          }
+          let sourceValue: string = JsonPointerService.get(source, sourceTypedPointer.pointer);
+          if (targetTypedPointer.type === 'number') {
+              JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ? parseFloat(sourceValue) : null);
+          } else if (sourceTypedPointer.type === 'date') {  // 'date' type will only be on the view side
+              JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ?
+                  MiscUtils.formatDateToDatetimeString(sourceValue) : null);
+          } else {
+              JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue);
+          }
+      }
+  }
 }

--- a/src/client/app/shared/json-data-view-model/json-view-model.service.spec.data.ts
+++ b/src/client/app/shared/json-data-view-model/json-view-model.service.spec.data.ts
@@ -104,7 +104,7 @@ export class JsonViewModelServiceSpecData {
                             },
                             type: {
                                 TYPE_NAME: 'GML_3_2_1.CodeType',
-                                value: ''
+                                value: 'some_type'
                             },
                             remarks: '',
                             extension: {
@@ -120,10 +120,6 @@ export class JsonViewModelServiceSpecData {
                             manufacturerDescription: '',
                             manufacturerSerialNumber: '3213',
                             igsModelCode: {
-                                TYPE_NAME: 'GEODESYML_0_4.IgsReceiverModelCodeType',
-                                value: ''
-                            },
-                            receiverType: {
                                 TYPE_NAME: 'GEODESYML_0_4.IgsReceiverModelCodeType',
                                 codeList:
                                     'http://xml.gov.au/icsm/geodesyml/codelists/antenna-receiver-codelists.xml' +

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -8,8 +8,8 @@ export abstract class AbstractViewModel {
     public dateInserted: string;
     public deletedReason: string;
     // datePicker will make into a Date but the data is to be made string.  DatePicker will take string as input.
-    public startDate: string|any;
-    public endDate: string|any;
+    public startDate: string | any;
+    public endDate: string | any;
 
     /**
      * Mapping to/from Data and View model fields.  See createFieldMappings().

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -7,8 +7,9 @@ export abstract class AbstractViewModel {
     public dateDeleted: string;
     public dateInserted: string;
     public deletedReason: string;
-    public startDate: string;
-    public endDate: string;
+    // datePicker will make into a Date but the data is to be made string.  DatePicker will take string as input.
+    public startDate: string|any;
+    public endDate: string|any;
 
     /**
      * Mapping to/from Data and View model fields.  See createFieldMappings().

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
@@ -58,10 +58,10 @@ export class SurveyedLocalTieViewModel extends AbstractViewModel {
             '/dz', 'number');
 
         this.addFieldMapping('/surveyedLocalTie/dateMeasured/value/0', 'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/surveyedLocalTie/notes', 'string',
-            '/notes', 'string');
+            '/notes', 'date');
     };
 
     /**

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
@@ -27,14 +27,14 @@ export class TemperatureSensorViewModel extends AbstractViewModel {
     createFieldMappings(): void {
         this.addFieldMapping('/temperatureSensor/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
             'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/temperatureSensor/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
             'string',
-            '/endDate', 'string');
+            '/endDate', 'date');
 
         this.addFieldMapping('/temperatureSensor/calibrationDate/value/0', 'string',
-            '/calibrationDate', 'string');
+            '/calibrationDate', 'date');
 
         this.addFieldMapping('/temperatureSensor/dataSamplingInterval', 'string',
             '/dataSamplingInterval', 'number');

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
@@ -24,14 +24,14 @@ export class WaterVaporSensorViewModel extends AbstractViewModel {
     createFieldMappings(): void {
         this.addFieldMapping('/waterVaporSensor/validTime/abstractTimePrimitive/gml:TimePeriod/beginPosition/value/0',
             'string',
-            '/startDate', 'string');
+            '/startDate', 'date');
 
         this.addFieldMapping('/waterVaporSensor/validTime/abstractTimePrimitive/gml:TimePeriod/endPosition/value/0',
             'string',
-            '/endDate', 'string');
+            '/endDate', 'date');
 
         this.addFieldMapping('/waterVaporSensor/calibrationDate/value/0', 'string',
-            '/calibrationDate', 'string');
+            '/calibrationDate', 'date');
 
         this.addFieldMapping('/waterVaporSensor/notes', 'string',
             '/notes', 'string');

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -73,9 +73,15 @@ body {
   padding-left: 1px;
   padding-right: 1px;
 }
-
+/* TODO: find what this is being applied to so can qualify.  Then change 'label.labeldisabled' to 'label.disabled' below */
 .disabled {
     display: none;
+    color: #888 !important;
+    pointer-events: none;
+    cursor: default;
+}
+
+label.labeldisabled {
     color: #888 !important;
     pointer-events: none;
     cursor: default;

--- a/src/client/css/main.css
+++ b/src/client/css/main.css
@@ -1,3 +1,4 @@
+
 /* GA
 html {
   height: 100%;
@@ -503,6 +504,7 @@ ul {
 .panel-level-3.gnss-invalid > .panel-heading {
   background-color: #fff1de !important;
 }
+label.ng-dirty,label.ng-dirty.ng-valid,
 input.ng-dirty.ng-valid,
 input.ng-dirty.ng-valid + .input-group-btn > .btn-calendar,
 select.ng-dirty.ng-valid,
@@ -510,6 +512,7 @@ textarea.ng-dirty.ng-valid {
   border-color: #00b300;
   background-color: #ebffeb;
 }
+label.ng-dirty.ng-invalid,
 input.ng-dirty.ng-invalid,
 input.ng-dirty.ng-invalid + .input-group-btn > .btn-calendar,
 select.ng-dirty.ng-invalid,
@@ -524,7 +527,7 @@ textarea.christine.ng-invalid {
   border-color: #ff1700;
 }
 
-input.ng-invalid, textarea.ng-invalid {
+label.ng-invalid, input.ng-invalid, textarea.ng-invalid {
     border-color: #ff1700 !important;
 }
 text-input.ng-invalid {


### PR DESCRIPTION
Fixed bug where DateTime wasn't being set as dirty once a change was made.  Required updating to a FormControl for the new reactive forms.

* Incomplete work - I plan to do the other work on subsequent PR(s)
* DateTimes now a static text box (instead of text input) and the DateTimePicker widget
* Date picker ignores any timezone and assumes local.  It outputs local such (eg. GMT+10) - set in our view model via the `formControlName`.  But our dates need to be UTC. 
* ViewModel changed to a 'date' type from 'string' for the Dates.  They are still actually a string, but 'date' is used to indicate may need to change the format of the date.   This is required because the data from the DatePicker is like 'Tue 04 Sept ...' but we need in '20170904T0:00:000Z' format in the data.  The translate is done in the ViewToData translator.

## Todo in later PR(s)
* Fix TimeZones as above
* Time setting can't be done until this TimeZone problem is fixed
* OK and Cancel buttons currently only close the dialog.  Need to implement Cancel to restore previous date.
* Use Date type in the view model exclusively (no more strings - but translate to/from data model)

