### PR TITLE
Remove free-for-all indexing

### DIFF
--- a/src/client/app/shared/json-data-view-model/view-model/site-log-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/site-log-view-model.ts
@@ -12,7 +12,6 @@ import { GnssReceiverViewModel } from '../../../gnss-receiver/gnss-receiver-view
  * View Model equivalent of ../data-model/SiteLogDataModel
  */
 export class SiteLogViewModel {
-    [key:string]: any;      // Allow easy object access without typescript error
     siteIdentification: any = {};
     siteLocation: any = {};
     gnssReceivers: GnssReceiverViewModel[];

--- a/src/client/app/site-log/site-log.component.ts
+++ b/src/client/app/site-log/site-log.component.ts
@@ -408,10 +408,11 @@ export class SiteLogComponent implements OnInit, OnDestroy {
      * When items are deleted they are given a dateRemoved, but aren't deleted until now (so they show up in the diff).
      */
     private removeDeletedItems() {
-        let items: string[] = Object.keys(this.siteLogModel);
-        for (let item of items) {
-            if (Array.isArray(this.siteLogModel[item])) {
-                this.removeDeletedGroupItems(this.siteLogModel[item]);
+        let keys: string[] = Object.keys(this.siteLogModel);
+        for (let key of keys) {
+            let item = (<any> this.siteLogModel)[key];
+            if (Array.isArray(item)) {
+                this.removeDeletedGroupItems(item);
             }
         }
     }


### PR DESCRIPTION
This declaration of `[]`-operator permits the type-checker to accept:

```
SiteLogViewModel s = new SiteLogViewModel();
s.foo = 'bar';
```

even though `foo` is undeclared in `SiteLogViewModel`.