### PR TITLE
GEOD-457 Fix timezone problem with DatePicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,8 @@
     "@types/deep-diff": "0.0.30",
     "@types/json-pointer": "^1.0.30",
     "@types/lodash": "4.14.61",
+    "@types/moment": "^2.13.0",
+    "@types/moment-timezone": "^0.2.34",
     "alertify.js": "^1.0.10",
     "babel-polyfill": "^6.22.0",
     "bootstrap": "3.3.7",
@@ -165,13 +167,14 @@
     "json-pointer": "file:lib/json-pointer-0.6.0.tgz",
     "lodash": "4.17.4",
     "moment": "^2.14.1",
+    "moment-timezone": "^0.5.13",
     "ng2-bootstrap": "~1.3.3",
     "ogc-schemas": "^2.6.1",
     "ogc-schemas-ga": "./lib/ogc-schemas-ga-2.6.2-SNAPSHOT.tgz",
     "oidc-client": "^1.3.0-beta.2",
+    "rxjs": "^5.2.0",
     "scroll-into-view": "1.7.1",
     "systemjs": "0.19.41",
-    "zone.js": "^0.8.4",
-    "rxjs": "^5.2.0"
+    "zone.js": "^0.8.4"
   }
 }

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.css
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.css
@@ -44,7 +44,7 @@
 }
 .calendar-popup .center-btns {
   margin: 0 auto;
-  width: 150px;
+  width: 70px;
 }
 @media (max-width: 767px) {
   .calendar-popup .center-btns {

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.html
@@ -7,7 +7,7 @@
     <div>
       <div class="input-group">
                <!--[formControlName]="controlName"-->
-          <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName), 'labeldisabled': isFormDisabled()}">{{datetime}}</label>
+          <label [ngClass]="{'ng-dirty': isDirty(controlName), 'ng-invalid': isInvalid(controlName), 'labeldisabled': isFormDisabled()}">{{datetime | date: 'yyyy-MM-dd HH:mm:ss'}}</label>
         <span class="input-group-btn z-lowest">
           <button id="calendar-btn" type="button"
                   class="btn btn-default btn-calendar z-lowest"
@@ -78,14 +78,7 @@
                     <button class="btn btn-ok"
                             (click)="closeDatetime()"
                             title="Set selected date/time and close calendar">
-                        <i class="glyphicon glyphicon-ok"></i>
-                        OK
-                    </button>
-                    <button class="btn btn-cancel pull-right"
-                            (click)="closeDatetime()"
-                            title="Cancel selected date/time and close calendar">
-                        <i class="glyphicon glyphicon-remove"></i>
-                        Cancel
+                        Close
                     </button>
                 </div>
             </div>

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -43,6 +43,9 @@ export class ProjectConfig extends SeedConfig {
       {src: 'ogc-schemas/lib/Filter_2_0.js', inject: 'libs'},
       {src: 'ogc-schemas/lib/OWS_1_1_0.js', inject: 'libs'},
       {src: 'ogc-schemas/lib/WFS_2_0.js', inject: 'libs'},
+      {src: 'moment', inject: 'libs'},
+      {src: 'moment-timezone/moment-timezone.js', inject: 'libs'},
+      //'builds/moment-timezone-with-data.js', inject: 'libs'}
     ];
 
     // Add `local` third-party libraries to be injected/bundled.
@@ -71,6 +74,11 @@ export class ProjectConfig extends SeedConfig {
         name: 'ng2-bootstrap/*',
         path: 'node_modules/ng2-bootstrap/bundles/ng2-bootstrap.umd.min.js'
       },
+        {
+            name: 'moment-timezone',
+            path: 'node_modules/moment-timezone/moment-timezone.js'
+            //builds/moment-timezone-with-data.js'
+        },
       {
         name: 'lodash',
         path: 'node_modules/lodash/lodash.js'
@@ -108,13 +116,14 @@ export class ProjectConfig extends SeedConfig {
         path: 'node_modules/traceur/bin/traceur.js'
       },
       {
+        name: 'oidc-client',
+        path: 'node_modules/oidc-client/lib/oidc-client.min.js'
+      },
+
+      {
         name: 'moment',
         path: 'node_modules/moment/moment.js'
       },
-      {
-        name: 'oidc-client',
-        path: 'node_modules/oidc-client/lib/oidc-client.min.js'
-      }
     ];
 
     this.addPackagesBundles(additionalPackages);


### PR DESCRIPTION
* Problem is that the DatePicker will convert any input time to local timezone (eg. GMT+10) and will output any value as local tz.  But we persist and present our values in UTC.
* Also changed from having 'OK' and 'Cancel' buttons to just a 'Close' as the data is written back immediately.  If the ability to cancel is desired then we can do that as a separate issue.
* I've found a bug that I'll work on next.  Its related to changing the date that is in a daylight savings period when you currently aren't in one (or vice-versa I assume).  For this reason I've left some pertinent debug in.