### PR TITLE
Fix new dates for Items to be the value at UTC.

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -75,6 +75,7 @@ module.exports = function (config) {
 
       { pattern: 'node_modules/ng2-bootstrap/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/moment/**/*.js', included: false, watched: false },
+      { pattern: 'node_modules/moment-timezone/*.js', included: false, watched: false },
       { pattern: 'node_modules/foreach/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/json-pointer/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/scroll-into-view/**/*.js', included: false, watched: false },

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
@@ -20,7 +20,7 @@ export function main() {
       expect(humiditySensorsViewModel.notes).toEqual('');
       expect(humiditySensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
       expect(humiditySensorsViewModel.calibrationDate).toBeDefined();
       expect(humiditySensorsViewModel.calibrationDate).not.toEqual('');
       expect(humiditySensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.spec.ts
@@ -20,7 +20,7 @@ export function main() {
       expect(humiditySensorsViewModel.notes).toEqual('');
       expect(humiditySensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime();
       expect(humiditySensorsViewModel.calibrationDate).toBeDefined();
       expect(humiditySensorsViewModel.calibrationDate).not.toEqual('');
       expect(humiditySensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-view-model.ts
@@ -16,7 +16,7 @@ export class HumiditySensorViewModel extends AbstractViewModel {
      */
     constructor(blank: boolean = false) {
         super();
-        this.calibrationDate = blank ? '' : MiscUtils.getPresentDateTime();
+        this.calibrationDate = blank ? '' : MiscUtils.getUTCDateTime();
         this.dataSamplingInterval = 0;
         this.accuracyPercentRelativeHumidity = 0;
         this.aspiration = '';

--- a/src/client/app/local-episodic-effect/local-episodic-effect-view-model.spec.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-view-model.spec.ts
@@ -14,7 +14,7 @@ export function main() {
 
       expect(localEpisodicEffectViewModel.event).toEqual('');
 
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
       expect(localEpisodicEffectViewModel.startDate).toBeDefined();
       expect(localEpisodicEffectViewModel.startDate).toContain(nowPart);
       expect(localEpisodicEffectViewModel.endDate).toEqual('');

--- a/src/client/app/local-episodic-effect/local-episodic-effect-view-model.spec.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-view-model.spec.ts
@@ -14,7 +14,7 @@ export function main() {
 
       expect(localEpisodicEffectViewModel.event).toEqual('');
 
-      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime();
       expect(localEpisodicEffectViewModel.startDate).toBeDefined();
       expect(localEpisodicEffectViewModel.startDate).toContain(nowPart);
       expect(localEpisodicEffectViewModel.endDate).toEqual('');

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
@@ -19,7 +19,7 @@ export function main() {
       expect(pressureSensorsViewModel.notes).toEqual('');
       expect(pressureSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime();
       expect(pressureSensorsViewModel.calibrationDate).toBeDefined();
       expect(pressureSensorsViewModel.calibrationDate).not.toEqual('');
       expect(pressureSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.spec.ts
@@ -19,7 +19,7 @@ export function main() {
       expect(pressureSensorsViewModel.notes).toEqual('');
       expect(pressureSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
       expect(pressureSensorsViewModel.calibrationDate).toBeDefined();
       expect(pressureSensorsViewModel.calibrationDate).not.toEqual('');
       expect(pressureSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-view-model.ts
@@ -16,7 +16,7 @@ export class PressureSensorViewModel extends AbstractViewModel {
      */
     constructor(blank: boolean = false) {
         super();
-        this.calibrationDate = MiscUtils.getPresentDateTime();
+        this.calibrationDate = MiscUtils.getUTCDateTime();
         this.dataSamplingInterval = 0;
         this.accuracyHPa = 0;
         this.notes = '';

--- a/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
@@ -120,15 +120,9 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
     ngOnInit() {
         this.itemGroup = <FormGroup> this.groupArray.at(this.index);
         this.addFields(this.itemGroup, this.getFormControls());
-        // For some reason, when - Open Group, Open Item, Close Group, Reopen Group, it is being marked as dirty
-        // NOTE that without the setTimeout() on the setValue(), a "was false now true" error occurs.  It seems that
-        // it is talking about the dirty status.  So something is happening deep in the angular lifecycle.  Hopefully
-        // they fix this.
         // Check its dirty status before doing the setValue() and restore to that state afterwards
         let wasDirty: boolean = this.itemGroup ? this.itemGroup.dirty : true;   // True because it is new
-        setTimeout(() => {
-            this.itemGroup.setValue(this.getItem());
-        });
+        this.itemGroup.setValue(this.getItem());
         if (!wasDirty) {
             setTimeout(() => {
                 this.itemGroup.markAsPristine();

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -306,16 +306,11 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             return null;
         }
 
-        try {
-            let date: Date = new Date(dtStr.substring(0, 19).replace(' ', 'T'));
-            if (date !== null && date.toString() !== 'Invalid Date') {
-                this.invalidDatetime = false;
-                return date;
-            }
-        } catch(error) {
-            console.log('Error:'+error);
+        let date: Date = new Date(dtStr);
+        if (MiscUtils.isDate(date)) {
+            this.invalidDatetime = false;
+            return date;
         }
-
         this.invalidDatetime = true;
         return null;
     }

--- a/src/client/app/shared/global/json-diff.service.spec.ts
+++ b/src/client/app/shared/global/json-diff.service.spec.ts
@@ -462,7 +462,7 @@ export function main() {
       // should be only one object entry in item.  Regardless descend into the first
       let theObject: any = getFirstObject(items, index);
 
-      let date: string = MiscUtils.getPresentDateTime();
+      let date: string = MiscUtils.getUTCDateTime();
 
       theObject.dateInserted = date;
 
@@ -481,7 +481,7 @@ export function main() {
       // should be only one object entry in item.  Regardless descend into the first
       let theObject: any = getFirstObject(items, index);
 
-      let date: string = MiscUtils.getPresentDateTime();
+      let date: string = MiscUtils.getUTCDateTime();
 
       theObject.dateDeleted = date;
 

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -1,13 +1,14 @@
 import * as lodash from 'lodash';
+import * as moment from 'moment-timezone';
 
 export class MiscUtils {
     private static scrollToView: any = require('scroll-into-view');
 
     /**
-     * Get present date and time string in format of "yyyy-mm-ddThh:mm:ss.sssZ"
+     * Get UTC date and time string in format of "yyyy-mm-dd hh:mm:ss"
      */
-    public static getPresentDateTime() {
-        return new Date().toISOString();
+    public static getUTCDateTime(): string {
+        return moment().utc().format("YYYY-MM-DD hh:mm:ss");
     }
 
     public static prettyFormatDateTime(date: string) {

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -8,7 +8,7 @@ export class MiscUtils {
      * Get UTC date and time string in format of "yyyy-mm-dd hh:mm:ss"
      */
     public static getUTCDateTime(): string {
-        return moment().utc().format("YYYY-MM-DD hh:mm:ss");
+        return moment().utc().format('YYYY-MM-DD hh:mm:ss');
     }
 
     public static prettyFormatDateTime(date: string) {

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -62,7 +62,7 @@ export abstract class AbstractViewModel {
      * @return the date so can use in FormModel
      */
     setDateInserted(): string {
-        let date: string = MiscUtils.getPresentDateTime();
+        let date: string = MiscUtils.getUTCDateTime();
         this.dateInserted = date;
         return date;
     }
@@ -72,7 +72,7 @@ export abstract class AbstractViewModel {
      * @return the date so can use in FormModel
      */
     setDateDeleted(): string {
-        let date: string = MiscUtils.getPresentDateTime();
+        let date: string = MiscUtils.getUTCDateTime();
         this.dateDeleted = date;
         return date;
     }
@@ -93,7 +93,7 @@ export abstract class AbstractViewModel {
      */
     setEndDateToCurrentDate(): Object {
         if (this.hasOwnProperty('endDate')) {
-            let presentDT: string = MiscUtils.getPresentDateTime();
+            let presentDT: string = MiscUtils.getUTCDateTime();
             this.endDate = presentDT;
             return {endDate: presentDT};
         } else {
@@ -126,7 +126,7 @@ export abstract class AbstractViewModel {
         this.dateDeleted = '';
         this.dateInserted = '';
         this.deletedReason = '';
-        this.startDate = MiscUtils.getPresentDateTime();
+        this.startDate = MiscUtils.getUTCDateTime();
         this.endDate = '';
     }
 

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
@@ -19,7 +19,7 @@ export function main() {
       expect(temperatureSensorsViewModel.notes).toEqual('');
       expect(temperatureSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime();
       expect(temperatureSensorsViewModel.calibrationDate).toBeDefined();
       expect(temperatureSensorsViewModel.calibrationDate).not.toEqual('');
       expect(temperatureSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.spec.ts
@@ -19,7 +19,7 @@ export function main() {
       expect(temperatureSensorsViewModel.notes).toEqual('');
       expect(temperatureSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
       expect(temperatureSensorsViewModel.calibrationDate).toBeDefined();
       expect(temperatureSensorsViewModel.calibrationDate).not.toEqual('');
       expect(temperatureSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-view-model.ts
@@ -15,7 +15,7 @@ export class TemperatureSensorViewModel extends AbstractViewModel {
      */
     constructor(blank: boolean = false) {
         super();
-        this.calibrationDate = blank ? '' : MiscUtils.getPresentDateTime();
+        this.calibrationDate = blank ? '' : MiscUtils.getUTCDateTime();
         this.dataSamplingInterval = 0;
         this.accuracyDegreesCelcius = 0;
         this.notes = '';

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
@@ -16,7 +16,7 @@ export function main() {
       expect(waterVaporSensorsViewModel.notes).toEqual('');
       expect(waterVaporSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getPresentDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
       expect(waterVaporSensorsViewModel.calibrationDate).toBeDefined();
       expect(waterVaporSensorsViewModel.calibrationDate).not.toEqual('');
       expect(waterVaporSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.spec.ts
@@ -9,14 +9,14 @@ export function main() {
       waterVaporSensorsViewModel = new WaterVaporSensorViewModel();
     });
 
-    it('test default constructor and all fields are created', () => {
+    fit('test default constructor and all fields are created', () => {
       expect(waterVaporSensorsViewModel).toBeDefined();
       expect(waterVaporSensorsViewModel.heightDiffToAntenna).toEqual(0);
       expect(waterVaporSensorsViewModel.manufacturer).toEqual('');
       expect(waterVaporSensorsViewModel.notes).toEqual('');
       expect(waterVaporSensorsViewModel.serialNumber).toEqual('');
       // The defaults for calibration and start date is now() - drop time when test for this
-      let nowPart: string = MiscUtils.getUTCDateTime().replace(/T.*/,'');
+      let nowPart: string = MiscUtils.getUTCDateTime();
       expect(waterVaporSensorsViewModel.calibrationDate).toBeDefined();
       expect(waterVaporSensorsViewModel.calibrationDate).not.toEqual('');
       expect(waterVaporSensorsViewModel.calibrationDate).toContain(nowPart);

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-view-model.ts
@@ -14,7 +14,7 @@ export class WaterVaporSensorViewModel extends AbstractViewModel {
      */
     constructor(blank: boolean = false) {
         super();
-        this.calibrationDate = blank ? '' : MiscUtils.getPresentDateTime();
+        this.calibrationDate = blank ? '' : MiscUtils.getUTCDateTime();
         this.notes = '';
         this.manufacturer = '';
         this.serialNumber = '';

--- a/test-config.js
+++ b/test-config.js
@@ -13,6 +13,8 @@ System.config({
       'performance-now': 'performance-now/lib/performance-now',
       'deep-diff': 'deep-diff/index',
       'oidc-client': 'oidc-client/lib/oidc-client',
+      'moment-timezone': 'moment-timezone/moment-timezone.js',
   }
 });
+
 


### PR DESCRIPTION
HOLD OFF APPROVING - I've found a bug related to UTC time in the picker.

**Sorry, continue to do this PR.**  The problem is unrelated - it is when you have a new item, the control value doesn't yet exist so the DateTime code for setting the date hours, minutes, seconds fields comes from a new Date(), which of course is not the UTC value.

**I have fixed that bug now** as part of this PR.