### PR TITLE
Remove unnecessary parsing to number

### DIFF
--- a/src/client/app/shared/json-data-view-model/data-view-translator.ts
+++ b/src/client/app/shared/json-data-view-model/data-view-translator.ts
@@ -70,9 +70,7 @@ export class DataViewTranslatorService {
               targetTypedPointer = fieldMap.dataTypedPointer;
           }
           let sourceValue: any = JsonPointerService.get(source, sourceTypedPointer.pointer);
-          if (targetTypedPointer.type === 'number') {
-              JsonPointerService.set(target, targetTypedPointer.pointer, sourceValue !== null ? parseFloat(sourceValue) : null);
-          } else if (sourceTypedPointer.type === 'date') {  // 'date' type will only be on the view side
+          if (sourceTypedPointer.type === 'date') {  // 'date' type will only be on the view side
               // Currently the dates can be string (from the database) or Date (as returned by DatePicker widget)
               // Must handle both (eg. AbstractViewModel.startDate)
               let dateValue: string = MiscUtils.isDate(sourceValue) ? MiscUtils.formatDateToDatetimeString(sourceValue) : sourceValue;


### PR DESCRIPTION
As defined by GeodesyML JSON schema, all relevant source values are already
numbers. Find relevant properties with `find src -name "*.ts" | xargs grep \'number\'`.