### PR TITLE
DateTime - new date defaults to UTC time

### DIFF
--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -137,7 +137,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         this.datetime = this.formatDatetimeToDisplay(this.formControl.value);
         let newDate: Date = this.convertStringToDate(this.datetime);
         if (newDate === null) {
-            this.datetimeModel = new Date();
+            this.datetimeModel = new Date(MiscUtils.getUTCDateTime());
         } else {
             this.datetimeModel = newDate;
         }


### PR DESCRIPTION
One problem with this is that the default date is at the time the dateTime component is created.