### PR TITLE
Geod 407 validation

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -37,15 +37,12 @@ export class FrequencyStandardItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {standardType: new FormControl('')},//, [Validators.minLength(4)]],
-            {inputFrequency: new FormControl('')},//, [Validators.maxLength(100)]],
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  //  requiredIfNotCurrent="true"
-            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {standardType: new FormControl('', [Validators.minLength(4)])},
+            {inputFrequency: new FormControl('', [Validators.maxLength(100)])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
+            {notes: new FormControl('', [Validators.maxLength(2000)])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},
             {dateInserted: new FormControl('')},

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -37,24 +37,21 @@ export class GnssAntennaItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {antennaType: new FormControl('')},//, [Validators.maxLength(100)]],
-            {serialNumber: new FormControl('')},//, [Validators.maxLength(100)]],
-            {startDate: new FormControl('')},//, [Validators.required, dateTimeFormatValidator]],
-            {endDate: new FormControl('')},    // requiredIfNotCurrent="true"
-            {antennaReferencePoint: new FormControl('')},//, [Validators.maxLength(100)]],
-            {markerArpEastEcc: new FormControl('')},//, [Validators.maxLength(100)]],
-            {markerArpUpEcc: new FormControl('')},//, [Validators.maxLength(100)]],
-            {markerArpNorthEcc: new FormControl('')},//, [Validators.maxLength(100)]],
-            {alignmentFromTrueNorth: new FormControl('')},//, [Validators.maxLength(100)]],
-            {antennaRadomeType: new FormControl('')},//, [Validators.maxLength(100)]],
-            {radomeSerialNumber: new FormControl('')},//, [Validators.maxLength(100)]],
-            {antennaCableType: new FormControl('')},//, [Validators.maxLength(100)]],
-            {antennaCableLength: new FormControl('')},//, [Validators.maxLength(100)]],
-            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {antennaType: new FormControl('', [Validators.maxLength(100)])},
+            {serialNumber: new FormControl('', [Validators.minLength(4)])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
+            {antennaReferencePoint: new FormControl('', [Validators.required])},
+            {markerArpEastEcc: new FormControl('', [Validators.maxLength(100)])},
+            {markerArpUpEcc: new FormControl('', [Validators.maxLength(100)])},
+            {markerArpNorthEcc: new FormControl('', [Validators.maxLength(100)])},
+            {alignmentFromTrueNorth: new FormControl('', [Validators.maxLength(100)])},
+            {antennaRadomeType: new FormControl('', [Validators.maxLength(100)])},
+            {radomeSerialNumber: new FormControl('', [Validators.maxLength(100)])},
+            {antennaCableType: new FormControl('', [Validators.maxLength(100)])},
+            {antennaCableLength: new FormControl('', [Validators.maxLength(100)])},
+            {notes: new FormControl('', [Validators.maxLength(2000)])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},
             {dateInserted: new FormControl('')},

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.html
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.html
@@ -30,7 +30,7 @@
             <text-input formControlName="firmwareVersion" controlName="firmwareVersion" [form]="itemGroup">Firmware Version</text-input>
             <text-input formControlName="satelliteSystem" controlName="satelliteSystem" [form]="itemGroup">Satellite System</text-input>
             <number-input formControlName="elevationCutoffSetting" controlName="elevationCutoffSetting" [form]="itemGroup"
-                [step]="1">Elevation Cutoff Setting (degrees)</number-input>
+                [step]="1" min="-359" max="359">Elevation Cutoff Setting (degrees)</number-input>
             <number-input formControlName="temperatureStabilization" controlName="temperatureStabilization" [form]="itemGroup"
                 [step]="1">Temperature Stabilization (&deg;C)</number-input>
             <datetime-input [form]="itemGroup" controlName="startDate">Date Installed (UTC)</datetime-input>

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -29,18 +29,15 @@ export class GnssReceiverItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {receiverType: new FormControl('')}, //, [Validators.maxLength(100)]],
+            {receiverType: new FormControl('', [Validators.maxLength(25)])},
             {manufacturerSerialNumber: new FormControl('', [Validators.maxLength(4)])},
-            {startDate: new FormControl('')},//, [Validators.required, dateTimeFormatValidator]],
-            {endDate: new FormControl('')},//, [requiredIfNotCurrent="true" , dateTimeFormatValidator]],
-            {firmwareVersion: new FormControl('')},//, [Validators.maxLength(100)]],
-            {satelliteSystem: new FormControl('')},//, [Validators.maxLength(100)]],
-            {elevationCutoffSetting: new FormControl('')},//, [Validators.maxLength(100)]],
-            {temperatureStabilization: new FormControl('')}, //, [Validators.required]],//, [Validators.maxLength(100)]],
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
+            {firmwareVersion: new FormControl('', [Validators.maxLength(25)])},
+            {satelliteSystem: new FormControl('', [Validators.maxLength(25)])},
+            {elevationCutoffSetting: new FormControl('', [Validators.maxLength(25)])},
+            {temperatureStabilization: new FormControl('', [Validators.required])}, // Validators.pattern(/^\d{1,3}$/) - works!
             {notes: new FormControl('', [Validators.maxLength(20)])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -41,16 +41,16 @@ export class HumiditySensorItemComponent extends AbstractItemComponent {
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {manufacturer: new FormControl('', [Validators.required, Validators.minLength(50)])},
+            {serialNumber: new FormControl('', [Validators.required, Validators.maxLength(50)])},
             {dataSamplingInterval: new FormControl('')},
             {accuracyPercentRelativeHumidity: new FormControl('')},
             {aspiration: new FormControl('')},
             {heightDiffToAntenna: new FormControl('')},
             {calibrationDate: new FormControl('')},
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
-            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
+            {notes: new FormControl('', [Validators.maxLength(2000)])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},
             {dateInserted: new FormControl('')},

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
@@ -37,13 +37,10 @@ export class LocalEpisodicEffectItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {event: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
+            {event: new FormControl('', [Validators.required, Validators.minLength(100)])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},
             {dateInserted: new FormControl('')},

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -37,19 +37,16 @@ export class PressureSensorItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {manufacturer: new FormControl('', [Validators.required, Validators.minLength(100)])},
+            {serialNumber: new FormControl('', [Validators.required, Validators.maxLength(100)])},
             {dataSamplingInterval: new FormControl('')},
             {accuracyHPa: new FormControl('')},
             {heightDiffToAntenna: new FormControl('')},
             {calibrationDate: new FormControl('')},
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
-            {notes: new FormControl(['', [Validators.maxLength(2000)]])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
+            {notes: new FormControl('', [Validators.maxLength(2000)])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},
             {dateInserted: new FormControl('')},

--- a/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
+++ b/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
@@ -1,6 +1,13 @@
 import { AbstractControl, FormGroup } from '@angular/forms';
+import { Input } from '@angular/core';
+
+export const validDatetimeFormat: RegExp = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[0-1]) ([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$/g;
+export const validDatetimeFormatHuman: string = 'YYYY-MM-DD hh:mm:ss';
 
 export abstract class AbstractGnssControls {
+    @Input() controlName: string;
+    @Input() form: FormGroup;
+
     private superForm: FormGroup;
 
     protected setForm(form: FormGroup) {
@@ -8,6 +15,9 @@ export abstract class AbstractGnssControls {
     }
 
     protected getErrorReport(controlId: string) {
+        if (! controlId) {
+            controlId = this.controlName;
+        }
         let errString: string = '';
         let control: AbstractControl;
         // Force an error as this field should have been set
@@ -17,12 +27,32 @@ export abstract class AbstractGnssControls {
             return errString;
         }
         if (control.errors) {
-            console.log('error report - control: ', controlId);
+            // console.log('error report - control: ', controlId);
             for (let e of Object.keys(control.errors)) {
-                console.log(e + ' -> ', control.errors[e]);
-                errString += e;
-                errString += ': ';
-                errString += JSON.stringify(control.errors[e]);
+                // console.log(e + ' -> ', control.errors[e]);
+                if (errString.length > 0) {
+                    errString += ", ";
+                }
+                if (e === 'maxlength') {
+                    errString += 'Maximum Length exceeded: ' + control.errors[e].requiredLength;
+                } else if (e === 'minlength') {
+                    errString += 'Minimum Length not reached: ' + control.errors[e].requiredLength;
+                } else if (e === 'pattern') {
+                    let pat: string;
+                    if (control.errors[e].requiredPattern === validDatetimeFormat.toString()) {
+                        pat = validDatetimeFormatHuman;
+                    } else {
+                        pat = control.errors[e].requiredPattern.toString();
+                    }
+                    errString += 'pattern required: ' + pat;
+                } else if (e === 'required') {
+                    errString += 'Field required';
+                } else if (e === 'outside_range') {
+                    errString += 'Outside range: '+control.errors[e];
+                } else {
+                    errString += e;
+                    errString += JSON.stringify(control.errors[e]);
+                }
             }
         }
         return errString;

--- a/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
+++ b/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
@@ -27,9 +27,7 @@ export abstract class AbstractGnssControls {
             return errString;
         }
         if (control.errors) {
-            // console.log('error report - control: ', controlId);
             for (let e of Object.keys(control.errors)) {
-                // console.log(e + ' -> ', control.errors[e]);
                 if (errString.length > 0) {
                     errString += ', ';
                 }
@@ -67,7 +65,6 @@ export abstract class AbstractGnssControls {
         } else {
             dirty = control.dirty;
         }
-        // console.warn('  isDirty Control "' + controlId + '": '+ dirty + ' - ', control);
         return dirty;
     }
 
@@ -80,7 +77,6 @@ export abstract class AbstractGnssControls {
         } else {
             valid = control.valid;
         }
-        // console.warn('  isValid Control "' + controlId + '": '+ valid + ' - ', control);
         return valid;
     }
 

--- a/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
+++ b/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
@@ -34,9 +34,9 @@ export abstract class AbstractGnssControls {
                     errString += ", ";
                 }
                 if (e === 'maxlength') {
-                    errString += 'Maximum Length exceeded: ' + control.errors[e].requiredLength;
+                    errString += 'Maximum length exceeded: ' + control.errors[e].requiredLength;
                 } else if (e === 'minlength') {
-                    errString += 'Minimum Length not reached: ' + control.errors[e].requiredLength;
+                    errString += 'Minimum length not reached: ' + control.errors[e].requiredLength;
                 } else if (e === 'pattern') {
                     let pat: string;
                     if (control.errors[e].requiredPattern === validDatetimeFormat.toString()) {

--- a/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
+++ b/src/client/app/shared/dynamic-form-fields/abstract-gnss-controls.ts
@@ -31,7 +31,7 @@ export abstract class AbstractGnssControls {
             for (let e of Object.keys(control.errors)) {
                 // console.log(e + ' -> ', control.errors[e]);
                 if (errString.length > 0) {
-                    errString += ", ";
+                    errString += ', ';
                 }
                 if (e === 'maxlength') {
                     errString += 'Maximum length exceeded: ' + control.errors[e].requiredLength;

--- a/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/datetime-input.component.ts
@@ -1,9 +1,7 @@
 import { Component, ElementRef, HostListener, Input, OnInit, DoCheck } from '@angular/core';
 import { AbstractControl, FormGroup } from '@angular/forms';
-import { AbstractGnssControls } from './abstract-gnss-controls';
+import { AbstractGnssControls, validDatetimeFormat, validDatetimeFormatHuman } from './abstract-gnss-controls';
 import { MiscUtils } from '../index';
-
-const validDatetimeFormat: RegExp = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[0-1]) ([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$/g;
 
 /**
  * This class represents the Datetime Input Component for choosing dates.
@@ -29,7 +27,6 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
     public datetime: string = '';
     public formControl: AbstractControl;
     @Input() public form: FormGroup;
-    @Input() public controlName: string;
     @Input() public required: boolean = true;
     @Input() public label: string = '';
 
@@ -261,7 +258,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
             this.invalidDatetime = true;
         } else {
             if (this.datetime
-                .match(/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2]\d|3[0-1]) ([0-1]\d|2[0-3]):([0-5]\d):([0-5]\d)$/g)) {
+                .match(validDatetimeFormat)) {
                 this.invalidDatetime = false;
             } else {
                 this.invalidDatetime = true;
@@ -281,7 +278,7 @@ export class DatetimeInputComponent extends AbstractGnssControls implements OnIn
         } else if (this.invalidDatetime) {
             message += ' not valid ';
         }
-        message += '(Valid Date Format: YYYY-MM-DD hh:mm:ss)';
+        message += '(Valid Date Format: ' + validDatetimeFormatHuman;
         return message;
     }
 

--- a/src/client/app/shared/dynamic-form-fields/number-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/number-input.component.html
@@ -10,6 +10,7 @@
              [formControlName]="controlName"
              class="form-control"
              min="{{min}}"
+             max="{{max}}"
              step="{{step}}"
              [(ngModel)]="value"/>
          <small>{{getErrorReport(controlName)}}</small>

--- a/src/client/app/shared/dynamic-form-fields/number-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/number-input.component.ts
@@ -1,17 +1,43 @@
-import { Component, Input, Output, EventEmitter, OnInit, forwardRef } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR, AbstractControl, FormGroup, NG_VALIDATORS } from '@angular/forms';
+import { Component, Input, OnInit, forwardRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR, NG_VALIDATORS, FormControl, ValidatorFn } from '@angular/forms';
 import { AbstractGnssControls } from './abstract-gnss-controls';
+import { MiscUtils } from '../global/misc-utils';
+
+const CHILD_FORM_VALUE_ACCESSOR = {
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => NumberInputComponent),
+    multi: true
+};
+
+const CHILD_FORM_VALIDATORS = {
+    provide: NG_VALIDATORS,
+    useExisting: forwardRef(() => NumberInputComponent),
+    multi: true
+};
+
+function validatorFnFactory(min: number, max: number) {
+    if (min === null) {
+        min = Number.MIN_SAFE_INTEGER ;
+    }
+    if (max === null) {
+        max = Number.MAX_SAFE_INTEGER;
+    }
+    return (control: FormControl): any => {
+        let value: number = MiscUtils.stringToNumber(control.value);
+        if (value && (value < min || value > max)) {
+            let arg: string = min+'..'+max;
+            return {outside_range: arg};
+        }
+        return null;
+    }
+}
 
 @Component({
     moduleId: module.id,
     selector: 'number-input',
     templateUrl: 'number-input.component.html',
     styleUrls: ['form-input.component.css'],
-        providers: [{
-        provide: NG_VALUE_ACCESSOR,
-        useExisting: forwardRef(() => NumberInputComponent),
-        multi: true
-    }]
+        providers: [CHILD_FORM_VALUE_ACCESSOR, CHILD_FORM_VALIDATORS]
 })
 export class NumberInputComponent extends AbstractGnssControls implements ControlValueAccessor, OnInit {
     @Input() index: string = '0';
@@ -20,18 +46,24 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
     @Input() public required: boolean = false;
     @Input() public step: string = '';
     @Input() public min: string = '';
-    @Input() public maxlength: string = '';
-    // controlName & form needed for validation
-    @Input() controlName: string;
-    @Input() form: FormGroup;
+    @Input() public max: string = '';
+
+    private validator: ValidatorFn;
 
     private _value: string = '';
+    private minNumber: number;
+    private maxNumber: number;
 
     propagateChange: Function = (_: any) => { };
     propagateTouch: Function = () => { };
 
     ngOnInit() {
         this.checkPreConditions();
+
+        this.maxNumber = MiscUtils.stringToNumber(this.max);
+        this.minNumber = MiscUtils.stringToNumber(this.min);
+        this.validator = validatorFnFactory(this.minNumber, this.maxNumber);
+
         super.setForm(this.form);
     }
 
@@ -40,7 +72,8 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
     }
 
     set value(value: string) {
-        if (value !== undefined && value !== this._value) {
+        let valueNumber: number = MiscUtils.stringToNumber(value);
+        if (value && value !== this._value && MiscUtils.isNumeric(valueNumber) && valueNumber >= this.minNumber && valueNumber <= this.maxNumber) {
             this._value = value;
             this.propagateChange(value);
         }
@@ -68,5 +101,9 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
         if (!this.form) {
             console.error('NumberInputComponent - form Input is required');
         }
+    }
+
+    validate(c: FormControl) {
+        return this.validator(c);
     }
 }

--- a/src/client/app/shared/dynamic-form-fields/number-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/number-input.component.ts
@@ -29,7 +29,7 @@ function validatorFnFactory(min: number, max: number) {
             return {outside_range: arg};
         }
         return null;
-    }
+    };
 }
 
 @Component({
@@ -73,7 +73,8 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
 
     set value(value: string) {
         let valueNumber: number = MiscUtils.stringToNumber(value);
-        if (value && value !== this._value && MiscUtils.isNumeric(valueNumber) && valueNumber >= this.minNumber && valueNumber <= this.maxNumber) {
+        if (value && value !== this._value && MiscUtils.isNumeric(valueNumber)
+            && valueNumber >= this.minNumber && valueNumber <= this.maxNumber) {
             this._value = value;
             this.propagateChange(value);
         }
@@ -94,6 +95,10 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
         this.propagateTouch = fn;
     }
 
+    validate(c: FormControl) {
+        return this.validator(c);
+    }
+
     private checkPreConditions() {
         if (!this.controlName || this.controlName.length === 0) {
             console.error('NumberInputComponent - controlName Input is required');
@@ -101,9 +106,5 @@ export class NumberInputComponent extends AbstractGnssControls implements Contro
         if (!this.form) {
             console.error('NumberInputComponent - form Input is required');
         }
-    }
-
-    validate(c: FormControl) {
-        return this.validator(c);
     }
 }

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.ts
@@ -18,9 +18,6 @@ export class TextInputComponent extends AbstractGnssControls implements ControlV
     @Input() name: string = '';
     @Input() label: string = '';
     // controlName & form needed for validation
-    @Input() controlName: string;
-    @Input() form: FormGroup;
-    @Input() required: boolean = false;
 
     private _value: string = '';
 
@@ -60,10 +57,10 @@ export class TextInputComponent extends AbstractGnssControls implements ControlV
 
     private checkPreConditions() {
         if (!this.controlName || this.controlName.length === 0) {
-            console.error('TextAreaInputComponent - controlName Input is required');
+            console.error('TextInputComponent - controlName Input is required');
         }
         if (!this.form) {
-            console.error('TextAreaInputComponent - form Input is required');
+            console.error('TextInputComponent - form Input is required');
         }
     }
 }

--- a/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/textarea-input.component.ts
@@ -22,9 +22,6 @@ export class TextAreaInputComponent extends AbstractGnssControls implements Cont
     @Input() public required: boolean = false;
     @Input() public rows: string = '';
     @Input() public maxlength: string = '';
-    // controlName & form needed for validation
-    @Input() controlName: string;
-    @Input() form: FormGroup;
     private _model: string = '';
 
     propagateChange: Function = (_: any) => { };

--- a/src/client/app/shared/global/misc-utils.ts
+++ b/src/client/app/shared/global/misc-utils.ts
@@ -34,7 +34,7 @@ export class MiscUtils {
     }
 
     public static formatDateToDateString(date: Date): string {
-        if (! MiscUtils.isDate(date)) {
+        if (!MiscUtils.isDate(date)) {
             throw new Error(`Input isnt a date - type: ${typeof date}, value: ${date}`);
         }
         let dateStr: string = date.getFullYear() + '-'
@@ -42,6 +42,7 @@ export class MiscUtils {
             + MiscUtils.padTwo(date.getDate());
         return dateStr;
     }
+
     /**
      * Return a date as a string in the "YYYY-MM-DD'T'hh:mm:ss.000Z" format.
      *
@@ -49,7 +50,7 @@ export class MiscUtils {
      * @return {string}
      */
     public static formatDateToDatetimeString(date: Date): string {
-        if (! MiscUtils.isDate(date)) {
+        if (!MiscUtils.isDate(date)) {
             throw new Error(`Input isnt a date - type: ${typeof date}, value: ${date}`);
         }
         let dateStr: string = MiscUtils.formatDateToDateString(date);
@@ -65,7 +66,7 @@ export class MiscUtils {
 
     public static isDate(date: Date): boolean {
         if (Object.prototype.toString.call(date) === '[object Date]') {
-            return ! isNaN(date.getTime());
+            return !isNaN(date.getTime());
         } else {
             return false;
         }
@@ -146,6 +147,24 @@ export class MiscUtils {
         } else {
             let settings: any = {time: 1000, align: {top: 0, left: 0}};
             this.scrollToView(elem, settings);
+        }
+    }
+
+    public static isNumeric(n: any) {
+        return !isNaN(parseFloat(n)) && isFinite(n);
+    }
+
+    public static stringToNumber(numStr: string): number {
+        if (typeof numStr === 'number') {
+            return numStr;
+        }
+        if (numStr && typeof numStr === 'string' && numStr.match(/\d+/)) {
+            return parseInt(numStr);
+        } else {
+            if (numStr) {
+                console.error('Not a number: ', numStr);
+            }
+            return null;
         }
     }
 }

--- a/src/client/app/site-log/site-identification.component.ts
+++ b/src/client/app/site-log/site-identification.component.ts
@@ -83,7 +83,8 @@ export class SiteIdentificationComponent implements OnInit {
     private setupForm() {
         this.siteIdentificationForm = this.formBuilder.group({
             siteName: ['', [Validators.minLength(4), Validators.maxLength(50)]],
-            fourCharacterID: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(25)]],
+            // '     ' prevents validation error at start
+            fourCharacterID: ['     ', [Validators.required, Validators.minLength(4), Validators.maxLength(25)]],
             monumentInscription: ['', [Validators.maxLength(100)]],
             iersDOMESNumber: ['', [Validators.maxLength(50)]],
             cdpNumber: ['', [Validators.maxLength(25)]],

--- a/src/client/app/site-log/site-identification.component.ts
+++ b/src/client/app/site-log/site-identification.component.ts
@@ -82,24 +82,24 @@ export class SiteIdentificationComponent implements OnInit {
 
     private setupForm() {
         this.siteIdentificationForm = this.formBuilder.group({
-            siteName: [''],//, [Validators.minLength(4), Validators.maxLength(100)]],
-            fourCharacterID: [''],//, [Validators.required, Validators.minLength(4), Validators.maxLength(9)]],
-            monumentInscription: [''],//, [Validators.maxLength(100)]],
-            iersDOMESNumber: [''],//, [Validators.maxLength(100)]],
-            cdpNumber: [''],//, [Validators.maxLength(100)]],
-            monumentDescription: [''],//, [Validators.maxLength(100)]],
+            siteName: ['', [Validators.minLength(4), Validators.maxLength(50)]],
+            fourCharacterID: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(25)]],
+            monumentInscription: ['', [Validators.maxLength(100)]],
+            iersDOMESNumber: ['', [Validators.maxLength(50)]],
+            cdpNumber: ['', [Validators.maxLength(25)]],
+            monumentDescription: ['', [Validators.maxLength(100)]],
             heightOfTheMonument: '',
-            monumentFoundation: [''],//, [Validators.maxLength(100)]],
+            monumentFoundation: ['', [Validators.maxLength(50)]],
             foundationDepth: '',
-            markerDescription: [''],//, [Validators.maxLength(100)]],
-            dateInstalled: [''],//, [Validators.maxLength(100)]],
-            geologicCharacteristic: [''],//, [Validators.maxLength(100)]],
-            bedrockType: [''],//, [Validators.maxLength(100)]],
-            bedrockCondition: [''],//, [Validators.maxLength(100)]],
-            fractureSpacing: [''],//, [Validators.maxLength(100)]],
-            faultZonesNearby: [''],//, [Validators.maxLength(100)]],
-            distanceActivity: [''],//, [Validators.maxLength(100)]],
-            notes: [''],//, [Validators.maxLength(2000)]],
+            markerDescription: ['', [Validators.maxLength(100)]],
+            dateInstalled: [''],    // Validators wont work in the DateTime custom component
+            geologicCharacteristic: ['', [Validators.maxLength(100)]],
+            bedrockType: ['', [Validators.maxLength(50)]],
+            bedrockCondition: ['', [Validators.maxLength(50)]],
+            fractureSpacing: ['', [Validators.maxLength(50)]],
+            faultZonesNearby: ['', [Validators.maxLength(50)]],
+            distanceActivity: ['', [Validators.maxLength(50)]],
+            notes: ['', [Validators.maxLength(2000)]],
         });
         if (this.userAuthService.hasAuthorityToEditSite()) {
             this.siteIdentificationForm.enable();

--- a/src/client/app/site-log/site-location.component.html
+++ b/src/client/app/site-log/site-location.component.html
@@ -1,5 +1,5 @@
 <div [formGroup]="siteLocationForm" class="panel panel-level-2"
-     [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': parentForm.invalid}">
+     [ngClass]="{'gnss-dirty': isFormDirty(), 'gnss-invalid': isFormInvalid()}">
     <div class="panel-heading">
         <span class="panel-title cursor-ptr"
               (click)="status.isSiteLocationGroupOpen = miscUtils.scrollIntoView($event, status.isSiteLocationGroupOpen)">

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -37,22 +37,19 @@ export class SurveyedLocalTieItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {tiedMarkerName: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
-            {tiedMarkerUsage: new FormControl('')},//, [Validators.maxLength(100)]],
-            {tiedMarkerCDPNumber: new FormControl('')},//, [Validators.maxLength(100)]],
-            {tiedMarkerDOMESNumber: new FormControl('')},//, [Validators.maxLength(100)]],
-            {dx: new FormControl('')},//, [Validators.maxLength(100)]],
-            {dy: new FormControl('')},//, [Validators.maxLength(100)]],
-            {dz: new FormControl('')},//, [Validators.maxLength(100)]],
-            {surveyMethod: new FormControl('')},//, [Validators.maxLength(100)]],
-            {localSiteTiesAccuracy: new FormControl('')},//, [Validators.maxLength(100)]],
-            {startDate: new FormControl('')},//, [Validators.maxLength(100)]],
+            {tiedMarkerName: new FormControl('', [Validators.minLength(25)])},
+            {tiedMarkerUsage: new FormControl('', [Validators.minLength(25)])},
+            {tiedMarkerCDPNumber: new FormControl('', [Validators.minLength(25)])},
+            {tiedMarkerDOMESNumber: new FormControl('', [Validators.minLength(25)])},
+            {dx: new FormControl('', [Validators.minLength(25)])},
+            {dy: new FormControl('', [Validators.minLength(25)])},
+            {dz: new FormControl('', [Validators.minLength(25)])},
+            {surveyMethod: new FormControl('', [Validators.minLength(25)])},
+            {localSiteTiesAccuracy: new FormControl('', [Validators.minLength(25)])},
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
             // TODO see GEOD-454 endDate not needed by this component but the value exists in the model
-            {endDate: new FormControl('')},//, [Validators.maxLength(100)]],
+            {endDate: new FormControl('')},
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -37,18 +37,15 @@ export class TemperatureSensorItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {manufacturer: new FormControl('', [Validators.required, Validators.minLength(25)])},
+            {serialNumber: new FormControl('', [Validators.required, Validators.minLength(25)])},
             {dataSamplingInterval: new FormControl('')},
             {accuracyDegreesCelcius: new FormControl('')},
             {heightDiffToAntenna: new FormControl('')},
             {calibrationDate: new FormControl('')},
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -37,16 +37,13 @@ export class WaterVaporSensorItemComponent extends AbstractItemComponent {
      * @return array of AbstractControl objects
      */
     getFormControls(): ItemControls {
-        // let itemGroup: FormGroup = formBuilder.group({
-        // turn off all Validators until work out solution to 'was false now true' problem
-        // TODO Fix Validators
         return new ItemControls([
-            {manufacturer: new FormControl('')},//, [Validators.required, Validators.minLength(100)]],
-            {serialNumber: new FormControl('')},//, [Validators.required, Validators.maxLength(100)]],
+            {manufacturer: new FormControl('', [Validators.required, Validators.minLength(25)])},
+            {serialNumber: new FormControl('', [Validators.required, Validators.minLength(25)])},
             {heightDiffToAntenna: new FormControl('')},
             {calibrationDate: new FormControl('')},
-            {startDate: new FormControl('')},//, [Validators.required]],
-            {endDate: new FormControl('')},  // requiredIfNotCurrent="true"
+            {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
+            {endDate: new FormControl('')},
             {notes: new FormControl(['', [Validators.maxLength(2000)]])},
             {objectMap: new FormControl('')},
             {dateDeleted: new FormControl('')},


### PR DESCRIPTION
* Improved Validation messages
* Fixed number custom component to take a max value and validate against min and max
* Fixed validation applied to item components

* The use of Validators.required causes a "was false now true" error, however this seems more of a warning - we must have fixed enough to prevent this being a fatal error.  I couldn't find a way to prevent this 'warning'.
* Not done was Validation for DateTime since ControlValueAccessor validation won't work for this unless it is modified.  HOWEVER I made some improvements to the DateTime around validation 