### PR TITLE
Remove ability to hide deleted items

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.spec.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.spec.ts
@@ -36,7 +36,7 @@ export function main() {
     let avmi3: AbstractViewModelImpl;
     let avmi4: AbstractViewModelImpl;
 
-    describe('AbstractGroup test - test showDeleted', () => {
+    describe('AbstractGroup test', () => {
 
         beforeEach(() => {
             abstractGroupImpl = new AbstractGroupImpl(null, null);
@@ -52,18 +52,7 @@ export function main() {
 
         it('test getItemsCollection()', () => {
             expect(abstractGroupImpl).toBeDefined();
-            // NOTE - general default (not configurable) - return items in reverse (sorted) order
-            // Default - don't show deleted
-            // 3,2,1 -> avmi2,4,3
-            let theDefault: AbstractViewModel[] = abstractGroupImpl.getItemsCollection(false);
-            expect(theDefault).toBeDefined();
-            expect(theDefault.length).toEqual(3);
-            expect(theDefault[0]).toEqual(avmi2);
-            expect(theDefault[1]).toEqual(avmi4);
-            expect(theDefault[2]).toEqual(avmi3);
-            expect(theDefault).not.toContain(avmi1);
 
-            // Show deleted
             // 4,3,2,1 -> avmi1,2,4,3
             let showDeleted: AbstractViewModel[] = abstractGroupImpl.getItemsCollection();
             expect(showDeleted).toBeDefined();
@@ -73,16 +62,6 @@ export function main() {
             expect(showDeleted[1]).toEqual(avmi2);
             expect(showDeleted[2]).toEqual(avmi4);
             expect(showDeleted[3]).toEqual(avmi3);
-
-            // Explicit don't show deleted
-            // 3,2,1 -> avmi2,4,3
-            let doNotShowDeleted: AbstractViewModel[] = abstractGroupImpl.getItemsCollection(false);
-            expect(doNotShowDeleted).toBeDefined();
-            expect(doNotShowDeleted.length).toEqual(3);
-            expect(doNotShowDeleted).not.toContain(avmi1);
-            expect(doNotShowDeleted[0]).toEqual(avmi2);
-            expect(doNotShowDeleted[1]).toEqual(avmi4);
-            expect(doNotShowDeleted[2]).toEqual(avmi3);
         });
     });
 
@@ -104,9 +83,9 @@ export function main() {
             countNotSet = 0;
         });
 
-        it('test when item has value changed it is reflected in original data - default', () => {
-            let showDeleted: AbstractViewModel[] = abstractGroupImpl.getItemsCollection(true);  // show deleted
-            let first: AbstractViewModelImpl = <AbstractViewModelImpl>showDeleted[0];
+        it('test when item has value changed it is reflected in original data', () => {
+            let items: AbstractViewModel[] = abstractGroupImpl.getItemsCollection();
+            let first: AbstractViewModelImpl = <AbstractViewModelImpl> items[0];
             expect(first.startDate).toEqual('4');
             first.startDate = '99';
             expect(first.startDate).toEqual('99');
@@ -114,28 +93,6 @@ export function main() {
             let theDefault: AbstractViewModel[] = abstractGroupImpl.getItemsCollection();
 
             for (let item of theDefault) {
-                let itemImpl = <AbstractViewModelImpl>item;
-                if (itemImpl.startDate && itemImpl.startDate === '99') {
-                    isSet = true;
-                } else {
-                    countNotSet++;
-                }
-            }
-            expect(isSet).toEqual(true);
-            expect(countNotSet).toBeGreaterThan(1);
-        });
-
-        it('test when item has value changed it is reflected in original data - doNotShowDeleted', () => {
-            let showDeleted: AbstractViewModel[] = abstractGroupImpl.getItemsCollection(true);  // showDeleted
-            let first: AbstractViewModelImpl = <AbstractViewModelImpl>showDeleted[0];
-            expect(first.startDate).toEqual('4');
-            first.startDate = '99';
-            expect(first.startDate).toEqual('99');
-
-            let doNotShowDeleted: AbstractViewModel[] = abstractGroupImpl.getItemsCollection(false);  // don't showDeleted
-            isSet = false;
-            countNotSet = 0;
-            for (let item of doNotShowDeleted) {
                 let itemImpl = <AbstractViewModelImpl>item;
                 if (itemImpl.startDate && itemImpl.startDate === '99') {
                     isSet = true;

--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -102,22 +102,11 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
     }
 
     /**
-     * Return collection - optionally with deleted items filter out.  Always in reverse order.
-     * @param showDeleted - true by default
+     * Return collection.
      * @return {T[]}
      */
-    getItemsCollection(showDeleted?: boolean): T[] {
-        let doShowDeleted: boolean = true;
-        if (showDeleted !== undefined) {
-            doShowDeleted = showDeleted;
-        }
-
-        if (this.itemProperties) {
-            let filteredOrNot: T[] = doShowDeleted ? lodash.clone(this.itemProperties) : this.itemProperties.filter(this.isntDeleted);
-            return filteredOrNot;
-        } else {
-            return [];
-        }
+    getItemsCollection(): T[] {
+        return this.itemProperties;
     }
 
     isEmptyCollection(): boolean {
@@ -308,10 +297,6 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
      */
     private sortUsingComparator(collection: any[]) {
         collection.sort(AbstractGroupComponent.compare);
-    }
-
-    private isntDeleted(item: T): boolean {
-        return (!item.dateDeleted || item.dateDeleted.length === 0);
     }
 
     /**


### PR DESCRIPTION
Something here was interfering with our recent initialisation of
`itemProperties`, so that we couldn't create items in empty collections.