### PR TITLE
allow readonly attribute and set for 4 char id

### DIFF
--- a/src/client/app/shared/dynamic-form-fields/text-input.component.html
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.html
@@ -6,6 +6,7 @@
     <div class="text-input" class="col-md-5 col-sm-6 col-xs-6 col-xxs-12">
          <input (keyup.enter)="ignoreEvent($event);"
              type="text"
+             readonly="{{readonly}}"
              [formControlName]="controlName"
              class="form-control"
              />

--- a/src/client/app/shared/dynamic-form-fields/text-input.component.ts
+++ b/src/client/app/shared/dynamic-form-fields/text-input.component.ts
@@ -17,6 +17,7 @@ export class TextInputComponent extends AbstractGnssControls implements ControlV
     @Input() index: string = '0';
     @Input() name: string = '';
     @Input() label: string = '';
+    @Input() public readonly: string = '';
 
     propagateChange: Function = (_: any) => { };
     propagateTouch: Function = () => { };
@@ -44,4 +45,5 @@ export class TextInputComponent extends AbstractGnssControls implements ControlV
             console.error('TextInputComponent - form Input is required');
         }
     }
+
 }

--- a/src/client/app/site-log/site-identification.component.html
+++ b/src/client/app/site-log/site-identification.component.html
@@ -20,7 +20,7 @@
         </div>
         <div class="margin-bottom15" *ngIf=" siteIdentification != null ">
             <div class="form-group">
-                <text-input formControlName="fourCharacterID" controlName="fourCharacterID"
+                <text-input readonly="readonly" formControlName="fourCharacterID" controlName="fourCharacterID"
                             [form]="siteIdentificationForm">Four Character Id
                 </text-input>
                 <text-input formControlName="siteName" controlName="siteName"


### PR DESCRIPTION
Note, I had thought that 'readonly=""' was invalid but it is valid html5 to use an empty string.
I still didn't work out why I can't set it to the value "readonly" in the html element but this works fine and is conformant so there's no real point figuring it out other than as a learning exercise.