### PR TITLE
Use public fields view models

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.spec.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.spec.ts
@@ -41,7 +41,7 @@ export function main() {
         beforeEach(() => {
             abstractGroupImpl = new AbstractGroupImpl(null, null);
             avmi1 = new AbstractViewModelImpl('4');
-            avmi1.setDateDeleted(MiscUtils.getUTCDateTime());
+            avmi1.dateDeleted = MiscUtils.getUTCDateTime();
             avmi2 = new AbstractViewModelImpl('3');
             avmi4 = new AbstractViewModelImpl('2');
             avmi3 = new AbstractViewModelImpl('1');

--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -195,8 +195,8 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
     public removeItem(index: number, reason: string) {
         let date: string = MiscUtils.getUTCDateTime();
         let item: T = this.getItemsCollection()[index];
-        item.setDateDeleted(date);
-        item.setDeletedReason(reason);
+        item.dateDeleted = date;
+        item.deletedReason= reason;
         if (this.groupArrayForm.length > index) {
             let formGroup: FormGroup = <FormGroup>this.groupArrayForm.at(index);
             if (formGroup.controls['dateDeleted']) {
@@ -215,7 +215,7 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
      */
     public cancelNew(itemIndex: number) {
         if (this.itemProperties.length > (itemIndex + 1) && !this.currentItemAlreadyHasEndDate) {
-            this.itemProperties[itemIndex+1].setEndDate('');
+            this.itemProperties[itemIndex+1].endDate = '';
             let formGroup: FormGroup = <FormGroup>this.groupArrayForm.at(itemIndex+1);
             if (formGroup.controls['endDate']) {
                 formGroup.controls['endDate'].setValue('');
@@ -264,13 +264,13 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
         let index: number = 0;
         let formGroup: FormGroup = <FormGroup>this.groupArrayForm.at(index);
 
-        item.setStartDate(dateUtc);
+        item.startDate = dateUtc;
         if (formGroup.controls['startDate']) {
             formGroup.controls['startDate'].setValue(dateUtc);
             formGroup.controls['startDate'].markAsDirty();
         }
 
-        item.setDateInserted(dateUtc);
+        item.dateInserted = dateUtc;
         if (formGroup.controls['dateInserted']) {
             formGroup.controls['dateInserted'].setValue(dateUtc);
         }
@@ -287,7 +287,7 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
             if (this.itemProperties[index].endDate) {
                 this.currentItemAlreadyHasEndDate = true;
             }
-            this.itemProperties[index].setEndDate(dateUtc);
+            this.itemProperties[index].endDate = dateUtc;
             let formGroup: FormGroup = <FormGroup>this.groupArrayForm.at(index);
             if (formGroup.controls['endDate']) {
                 formGroup.controls['endDate'].setValue(dateUtc);

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -65,26 +65,6 @@ export abstract class AbstractViewModel {
         return true;
     }
 
-    setStartDate(date: string) {
-        this.startDate = date;
-    }
-
-    setEndDate(date: string) {
-        this.endDate = date;
-    }
-
-    setDateInserted(date: string) {
-        this.dateInserted = date;
-    }
-
-    setDateDeleted(date: string) {
-        this.dateDeleted = date;
-    }
-
-    setDeletedReason(reason: string): void {
-        this.deletedReason = reason;
-    }
-
     /**
      * Simple way to specify the data / view model mappings.
      * @returns string[][]


### PR DESCRIPTION
First commit in attemt to simplify the view models. If they can
become dumb DTOs, then we could perhaps remove them altogether and use
only reactive form controls.