### PR TITLE
Move `hasEndDateField` into group components

### DIFF
--- a/src/client/app/responsible-party/responsible-party-group.component.ts
+++ b/src/client/app/responsible-party/responsible-party-group.component.ts
@@ -51,6 +51,10 @@ export class ResponsiblePartyGroupComponent extends AbstractGroupComponent<Respo
         return 0;
     }
 
+    protected hasEndDateField(): boolean {
+        return false;
+    }
+
     @Input()
     set partyType(partyType: ResponsiblePartyType) {
         this._partyType = partyType;
@@ -75,5 +79,4 @@ export class ResponsiblePartyGroupComponent extends AbstractGroupComponent<Respo
     newItemViewModel(): ResponsiblePartyViewModel {
         return new ResponsiblePartyViewModel();
     }
-
 }

--- a/src/client/app/responsible-party/responsible-party-view-model.ts
+++ b/src/client/app/responsible-party/responsible-party-view-model.ts
@@ -53,11 +53,4 @@ export class ResponsiblePartyViewModel extends AbstractViewModel {
             'characterString/gco:CharacterString',
             'string', '/fax', 'string');
     };
-
-    /**
-     * Overridden parent method to return false because ResponsibleParty does not have an end date.
-     */
-    hasEndDateField(): boolean {
-        return false;
-    }
 }

--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -246,6 +246,15 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
         this.isGroupOpen = this.miscUtils.scrollIntoView(event, this.isGroupOpen);
     }
 
+    /**
+     * Do items in this group have end dates?
+     */
+    // TODO: Ideally, there should be different subclasses of (all of, or some of) AbstractViewModel,
+    // AbstractItemComponent, and AbstractGroupComponent to denote cases where change management applies.
+    protected hasEndDateField(): boolean {
+        return true;
+    }
+
     /* ************** Private Methods ************** */
 
     private addNewItem(): void {
@@ -283,7 +292,7 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
      */
     private updateEndDateForSecondItem(dateUtc: string) {
         let index: number = 1;
-        if (this.itemProperties.length > 1 && this.itemProperties[index].hasEndDateField() ) {
+        if (this.itemProperties.length > 1 && this.hasEndDateField()) {
             if (this.itemProperties[index].endDate) {
                 this.currentItemAlreadyHasEndDate = true;
             }

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -56,16 +56,6 @@ export abstract class AbstractViewModel {
     }
 
     /**
-     * Returns true if this kind of objects have an end date.
-     *
-     * SiteIdentification, SiteLocation, ResponsibleParty and SurveyedLocalTie must override this method to return
-     * false as they do not have an end date.
-     */
-    hasEndDateField() : boolean {
-        return true;
-    }
-
-    /**
      * Simple way to specify the data / view model mappings.
      * @returns string[][]
      */

--- a/src/client/app/site-log/site-identification-view-model.ts
+++ b/src/client/app/site-log/site-identification-view-model.ts
@@ -86,11 +86,4 @@ export class SiteIdentificationViewModel extends AbstractViewModel {
 
         this.addFieldMapping('/objectMap', 'object', '/objectMap', 'object');
     };
-
-    /**
-     * Overridden parent method to return false because SiteIdentification does not have an end date.
-     */
-    hasEndDateField(): boolean {
-        return false;
-    }
 }

--- a/src/client/app/site-log/site-location-view-model.ts
+++ b/src/client/app/site-log/site-location-view-model.ts
@@ -55,11 +55,4 @@ export class SiteLocationViewModel extends AbstractViewModel {
         this.addSuperFieldMappings();
         this.addFieldMapping('/objectMap', 'object', '/objectMap', 'object');
     };
-
-    /**
-     * Overridden parent method to return false because SiteLocation does not have an end date.
-     */
-    hasEndDateField(): boolean {
-        return false;
-    }
 }

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-view-model.ts
@@ -47,11 +47,4 @@ export class SurveyedLocalTieViewModel extends AbstractViewModel {
         this.addFieldMapping('/surveyedLocalTie/notes', 'string',
             '/notes', 'date');
     };
-
-    /**
-     * Overridden parent method to return false because SurveyedLocalTie does not have an end date.
-     */
-    hasEndDateField(): boolean {
-        return false;
-    }
 }

--- a/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-ties-group.component.ts
@@ -32,4 +32,8 @@ export class SurveyedLocalTiesGroupComponent extends AbstractGroupComponent<Surv
     newItemViewModel(): SurveyedLocalTieViewModel {
         return new SurveyedLocalTieViewModel();
     }
+
+    protected hasEndDateField(): boolean {
+        return false;
+    }
 }


### PR DESCRIPTION
If we can make abstract view models into dumb DTOs, then we could
perhaps remove them altogether and just use reactive control forms.

Besides, we don't need to ask each data item if it has an end date
field, since this is known statically.