### PR TITLE
Use patchValue to avoid hidden form controls

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
@@ -136,7 +136,7 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
 
         this.itemGroup = <FormGroup> this.groupArray.at(this.index);
         this.addFields(this.itemGroup, this.getFormControls());
-        this.itemGroup.setValue(this.getItem());
+        this.itemGroup.patchValue(this.getItem());
     }
 
     /**


### PR DESCRIPTION
Currently, all abstract view items have a property called `objectMap`,
which is not a data field. Using `setValue` forces us to add such properties
to reactive forms as hidden controls.