### PR TITLE
e2e, use host network mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
         - http_proxy
         - https_proxy
     image: e2e-tests
+    network_mode: "host"
     volumes:
         - .:/home/tester/gnss-site-manager
         - /tmp/.X11-unix:/tmp/.X11-unix


### PR DESCRIPTION
This simplifies the set up required for the e2e-tests container to open a
window  when docker is running inside VirtualBox on Windows with X11
forwarding.