### PR TITLE
Drop subscription suffix from observable

### DIFF
--- a/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-item.component.ts
@@ -125,7 +125,7 @@ export abstract class AbstractItemComponent extends AbstractBaseComponent implem
     }
 
     ngOnInit() {
-        this.siteLogService.getApplicationStateSubscription().subscribe((applicationState: ApplicationState) => {
+        this.siteLogService.getApplicationState().subscribe((applicationState: ApplicationState) => {
             if (! applicationState.applicationFormModified) {
                 this.itemGroup.markAsPristine();
             }

--- a/src/client/app/shared/site-log/site-log.service.ts
+++ b/src/client/app/shared/site-log/site-log.service.ts
@@ -149,7 +149,7 @@ export class SiteLogService implements OnDestroy {
      * Method to allow clients to subscribe to know about application state changes.
      * @return {Observable<ApplicationStateSubject>}
      */
-    getApplicationStateSubscription(): Observable<ApplicationState> {
+    getApplicationState(): Observable<ApplicationState> {
         return this.applicationStateSubject.asObservable();
     }
 

--- a/src/client/app/shared/status-info/status-info.component.ts
+++ b/src/client/app/shared/status-info/status-info.component.ts
@@ -85,7 +85,7 @@ export class StatusInfoComponent implements OnInit, OnDestroy {
     }
 
     private setupSiteLogSubscription(): void {
-        this.siteLogService.getApplicationStateSubscription()
+        this.siteLogService.getApplicationState()
             .takeUntil(this.unsubscribe)
             .subscribe((applicationState: ApplicationState) => {
                 this.isFormModified = applicationState.applicationFormModified;

--- a/src/client/app/shared/toolbar/toolbar.component.ts
+++ b/src/client/app/shared/toolbar/toolbar.component.ts
@@ -165,7 +165,7 @@ export class ToolbarComponent implements OnInit, OnDestroy {
     }
 
     private setupSiteLogSubscription(): void {
-        this.siteLogService.getApplicationStateSubscription()
+        this.siteLogService.getApplicationState()
             .takeUntil(this.unsubscribe)
             .subscribe((applicationState: ApplicationState) => {
                 this.isFormModified = applicationState.applicationFormModified;

--- a/src/client/app/site-log/site-location.component.spec.ts
+++ b/src/client/app/site-log/site-location.component.spec.ts
@@ -24,7 +24,7 @@ export function main() {
         };
 
         let fakeSiteLogService = {
-            getApplicationStateSubscription(): Observable<any> {
+            getApplicationState(): Observable<any> {
                 return new Observable((observer: Subscriber<any>) => {
                     let applicationState: ApplicationState = {
                         applicationFormModified: false,

--- a/src/client/app/site-log/site-location.component.ts
+++ b/src/client/app/site-log/site-location.component.ts
@@ -58,7 +58,7 @@ export class SiteLocationComponent extends AbstractBaseComponent implements OnIn
 
     ngOnInit() {
         this.setupForm();
-        this.siteLogService.getApplicationStateSubscription().subscribe((applicationState: ApplicationState) => {
+        this.siteLogService.getApplicationState().subscribe((applicationState: ApplicationState) => {
             if (applicationState.applicationSaveState === ApplicationSaveState.saved) {
                 this.isNew = false;
                 this.isDeleted = false;


### PR DESCRIPTION
It's long and misleading. There is an actual `subscription` in rxjs, and
it's not an observable. See
https://github.com/ReactiveX/rxjs/blob/master/doc/subscription.md.