### PR TITLE
Return empty observable instead of emitting null

### DIFF
--- a/src/client/app/shared/site-log/prefetch-site-log.service.ts
+++ b/src/client/app/shared/site-log/prefetch-site-log.service.ts
@@ -23,7 +23,7 @@ export class PrefetchSiteLogResolver implements Resolve<SiteLogViewModel> {
                 this.router.navigate([homeUrl]);
                 this.dialogService.showErrorMessage('No site log found for ' + fourCharacterId);
                 console.log(error);
-                return Observable.of(null);
+                return Observable.empty();
             });
     }
 }


### PR DESCRIPTION
Returning `empty` has the advantage of not emitting a value when there
isn't one, which is preferable to emitting null. The observable is
terminated normally.