### PR TITLE
Use nix chromedriver if available

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -9,6 +9,7 @@ const config = {
 
   // 'jasmine' by default will use the latest jasmine framework
   framework: 'jasmine',
+  chromeDriver: process.env.CHROMEDRIVER_BIN ? process.env.CHROMEDRIVER_BIN : undefined,
 
   // allScriptsTimeout: 110000,
 
@@ -23,7 +24,10 @@ const config = {
   directConnect: true,
 
   capabilities: {
-    browserName: 'chrome'
+    browserName: 'chrome',
+    chromeOptions: {
+        binary: process.env.CHROME_BIN,
+    },
   },
 
   onPrepare: function() {

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ let
       xvfb_run
       pythonPackages.docker_compose
       xorg.xhost
+      chromedriver
     ];
   };
 in
@@ -31,7 +32,8 @@ in
     ];
     shellHook = ''
       export PATH=./node_modules/.bin:$PATH
-      export CHROME_BIN=chromium
+      export CHROME_BIN=$(which chromium)
+      export CHROMEDRIVER_BIN=$(which chromedriver)
       xhost +
     '';
   } ""


### PR DESCRIPTION
Chromedriver binary downloaded by webdriver-manager does not work on
NixOS. NixOS is not binary-compatible with any other Linux distribution.

This PR introduced an alternative to running e2e tests inside a docker container.