### PR TITLE
Fix typescript to 2.3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "w3c-schemas": "~1.4.0",
     "ts-node": "^2.0.0",
     "tslint": "^4.3.0",
-    "typescript": "^2.1.5",
+    "typescript": "~2.3.4",
     "walk": "^2.3.9",
     "yargs": "^6.0.0"
   },


### PR DESCRIPTION
Typescript version 2.4.1 has been released and this breaks for us.