### PR TITLE
Don't remove deleted log items from the site log

### DIFF
--- a/src/client/app/frequency-standard/frequency-standard-item.component.ts
+++ b/src/client/app/frequency-standard/frequency-standard-item.component.ts
@@ -41,6 +41,7 @@ export class FrequencyStandardItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {standardType: new FormControl('', [Validators.maxLength(200)])},
             {inputFrequency: new FormControl('', [Validators.maxLength(25)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component

--- a/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
+++ b/src/client/app/gnss-antenna/gnss-antenna-item.component.ts
@@ -41,6 +41,7 @@ export class GnssAntennaItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {antennaType: new FormControl('', [Validators.maxLength(100)])},
             {serialNumber: new FormControl('', [Validators.maxLength(50)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component

--- a/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receiver-item.component.ts
@@ -33,6 +33,7 @@ export class GnssReceiverItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {receiverType: new FormControl(' ', [Validators.maxLength(25)])},
             {manufacturerSerialNumber: new FormControl('', [Validators.maxLength(25)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component

--- a/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
+++ b/src/client/app/humidity-sensor/humidity-sensor-item.component.ts
@@ -44,6 +44,7 @@ export class HumiditySensorItemComponent extends AbstractItemComponent {
         // turn off all Validators until work out solution to 'was false now true' problem
         // TODO Fix Validators
         return new ItemControls([
+            {id: new FormControl(null)},
             {manufacturer: new FormControl('', [Validators.required, Validators.maxLength(50)])},
             {serialNumber: new FormControl('', [Validators.required, Validators.maxLength(50)])},
             {dataSamplingInterval: new FormControl('', [Validators.maxLength(25)])},

--- a/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
+++ b/src/client/app/local-episodic-effect/local-episodic-effect-item.component.ts
@@ -41,6 +41,7 @@ export class LocalEpisodicEffectItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {event: new FormControl('', [Validators.required, Validators.maxLength(100)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
             {endDate: new FormControl('')},

--- a/src/client/app/multipath-source/multipath-source-item.component.ts
+++ b/src/client/app/multipath-source/multipath-source-item.component.ts
@@ -41,6 +41,7 @@ export class MultipathSourceItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {possibleProblemSource: new FormControl('', [Validators.maxLength(100)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
             {endDate: new FormControl('')},

--- a/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
+++ b/src/client/app/pressure-sensor/pressure-sensor-item.component.ts
@@ -41,6 +41,7 @@ export class PressureSensorItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {manufacturer: new FormControl('', [Validators.required, Validators.maxLength(100)])},
             {serialNumber: new FormControl('', [Validators.required, Validators.maxLength(100)])},
             {dataSamplingInterval: new FormControl('', [Validators.maxLength(25)])},

--- a/src/client/app/radio-interference/radio-interference-item.component.ts
+++ b/src/client/app/radio-interference/radio-interference-item.component.ts
@@ -41,6 +41,7 @@ export class RadioInterferenceItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {observedDegradation: new FormControl('', [Validators.maxLength(100)])},
             {possibleProblemSource: new FormControl('', [Validators.maxLength(100)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component

--- a/src/client/app/responsible-party/responsible-party-item.component.ts
+++ b/src/client/app/responsible-party/responsible-party-item.component.ts
@@ -90,6 +90,7 @@ export class ResponsiblePartyItemComponent extends AbstractItemComponent impleme
         let organisationValidators: any[] = this.isDataType ? [Validators.required, Validators.maxLength(100)]
                                                             : [Validators.maxLength(100)];
         return new ItemControls([
+            {id: new FormControl(null)},
             {individualName: new FormControl('', [Validators.maxLength(100)])},
             {organisationName: new FormControl('', organisationValidators)},
             {positionName: new FormControl('', [Validators.maxLength(50)])},

--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -1,4 +1,4 @@
-import { Input, OnInit } from '@angular/core';
+import { Input, OnChanges, SimpleChange } from '@angular/core';
 import { FormGroup, FormArray, FormBuilder } from '@angular/forms';
 import { AbstractBaseComponent } from './abstract-base.component';
 import { GeodesyEvent, EventNames } from '../events-messages/Event';
@@ -10,7 +10,7 @@ import * as _ from 'lodash';
 
 export const newItemShouldBeBlank: boolean = true;
 
-export abstract class AbstractGroupComponent<T extends AbstractViewModel> extends AbstractBaseComponent implements OnInit {
+export abstract class AbstractGroupComponent<T extends AbstractViewModel> extends AbstractBaseComponent implements OnChanges {
     isGroupOpen: boolean = false;
 
     // flag to indicate that the current or latest item in a group has an end date set
@@ -65,8 +65,10 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
         super(userAuthService);
     }
 
-    ngOnInit() {
-        this.setupForm();
+    ngOnChanges(changes: { [property: string]: SimpleChange }) {
+        if (changes['siteLogModel']) {
+            this.setupForm();
+        }
     }
 
     /**
@@ -105,7 +107,10 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel> extend
 
     setItems(items: T[]) {
         if (items) {
-            this.items = items;
+            items.forEach((element: T, i: number) => {
+                element.id = i;
+            });
+            this.items = _.filter(items, item => !item.dateDeleted);
             this.items.sort(AbstractGroupComponent.compare);
             this.items.forEach(() => {
                 this.groupArrayForm.insert(0, new FormGroup({}));

--- a/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
+++ b/src/client/app/shared/json-data-view-model/view-model/abstract-view-model.ts
@@ -1,4 +1,5 @@
 export abstract class AbstractViewModel {
+    public id: number = null;
     public startDate: string | any = null;
     public endDate: string | any = null;
     public dateInserted: string = null;

--- a/src/client/app/signal-obstruction/signal-obstruction-item.component.ts
+++ b/src/client/app/signal-obstruction/signal-obstruction-item.component.ts
@@ -41,6 +41,7 @@ export class SignalObstructionItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {possibleProblemSource: new FormControl('', [Validators.maxLength(100)])},
             {startDate: new FormControl('')},   // Validators wont work in the DateTime custom component
             {endDate: new FormControl('')},

--- a/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
+++ b/src/client/app/surveyed-local-tie/surveyed-local-tie-item.component.ts
@@ -41,6 +41,7 @@ export class SurveyedLocalTieItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {tiedMarkerName: new FormControl('', [Validators.maxLength(50)])},
             {tiedMarkerUsage: new FormControl('', [Validators.maxLength(50)])},
             {tiedMarkerCDPNumber: new FormControl('', [Validators.maxLength(25)])},

--- a/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
+++ b/src/client/app/temperature-sensor/temperature-sensor-item.component.ts
@@ -41,6 +41,7 @@ export class TemperatureSensorItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {manufacturer: new FormControl(' ', [Validators.required, Validators.maxLength(50)])},
             {serialNumber: new FormControl(' ', [Validators.required, Validators.maxLength(25)])},
             {dataSamplingInterval: new FormControl('', [Validators.maxLength(25)])},

--- a/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
+++ b/src/client/app/water-vapor-sensor/water-vapor-sensor-item.component.ts
@@ -41,6 +41,7 @@ export class WaterVaporSensorItemComponent extends AbstractItemComponent {
      */
     getFormControls(): ItemControls {
         return new ItemControls([
+            {id: new FormControl(null)},
             {manufacturer: new FormControl('', [Validators.maxLength(25)])},
             {serialNumber: new FormControl('', [Validators.maxLength(25)])},
             {heightDiffToAntenna: new FormControl('', [Validators.maxLength(25)])},


### PR DESCRIPTION
Change tracking fields `dateDeleted` and `reasonDeleted` are used to
mark log items as deleted.

This PR introduces a new `id` in the view model item classes and the form controls to facilitate the merging of user input into the data model. Tracking items by identity, rather than position, allows us to remove deleted items from the view, but not from the data model. Item identity also makes item order irrelevant, so it may, in the future, allow us to delete the code that sorts item lists on save.