### PR TITLE
Fix an importing issue in PrefetchCorsNetworkResolver class

### DIFF
--- a/src/client/app/shared/cors-network/prefetch-cors-network.service.ts
+++ b/src/client/app/shared/cors-network/prefetch-cors-network.service.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@angular/core';
-import { Router, Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import { DialogService, CorsNetworkService } from '../index';
+import { DialogService } from '../global/dialog.service';
+import { CorsNetworkService } from './cors-network.service';
 import { CorsNetworkModel } from './cors-network-model';
 
 @Injectable()
-export class PrefetchCorsNetworkResolver implements Resolve<CorsNetworkModel> {
+export class PrefetchCorsNetworkResolver implements Resolve<CorsNetworkModel[]> {
 
-    constructor(private router: Router,
-                private dialogService: DialogService,
+    constructor(private dialogService: DialogService,
                 private corsNetworkService: CorsNetworkService) {
     }
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CorsNetworkModel> {
+    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<CorsNetworkModel[]> {
         return this.corsNetworkService.getAllCorsNetworks()
             .catch((error: any): any => {
                 this.dialogService.showErrorMessage('Warning: no CORS networks found.');


### PR DESCRIPTION
Importing files from index.ts caused a error when loading webpage:

`Error: Can't resolve all parameters for PrefetchCorsNetworkResolver: ([object Object], ?, ?)`

This is likely a circular dependency issue resulting from importing files from index.ts. It is a good to import each file separately.