### PR TITLE
Refactor addNewByCopying method in GNSS receiver component and move it to parent class

### DIFF
--- a/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
+++ b/src/client/app/gnss-receiver/gnss-receivers-group.component.ts
@@ -35,29 +35,18 @@ export class GnssReceiversGroupComponent extends AbstractGroupComponent<GnssRece
     }
 
     /**
-     * Add a new GNSS Receiver by copying and updating values from the current one
+     * Copy values from the current item to the new item created, and disable key fields if required.
      */
-    addNewByCopying(event: UIEvent) {
-        if (!this.hasItems()) {
-            return;
-        }
+    copyValuesFromCurrentItem(newItemForm: FormGroup, currentItemForm: FormGroup): void {
+        let filedsToCopy = ['receiverType', 'manufacturerSerialNumber', 'firmwareVersion',
+                            'satelliteSystems', 'elevationCutoffSetting', 'temperatureStabilization'];
+        let valuesToCopy = _.pick(currentItemForm.getRawValue(), filedsToCopy);
+        newItemForm.patchValue(_.cloneDeep(valuesToCopy));
 
-        this.addNew(event);
-
-        let fieldsToKeep = ['receiverType', 'manufacturerSerialNumber', 'firmwareVersion',
-                            'satelliteSystems', 'elevationCutoffSetting',
-                            'temperatureStabilization'];
+        // Disable of the two fileds must be after patchValue() completed, so need the 2nd setTimeout
         setTimeout(() => {
-            let newFormGroup = <FormGroup>this.parentForm.at(0);
-            let oldFormGroup = <FormGroup>this.parentForm.at(1);
-            let valuesToCopy = _.pick(oldFormGroup.getRawValue(), fieldsToKeep);
-            newFormGroup.patchValue(valuesToCopy);
-
-            // Disable of the two fileds must be after patchValue() completed, so need the 2nd setTimeout
-            setTimeout(() => {
-                newFormGroup.controls.receiverType.disable();
-                newFormGroup.controls.manufacturerSerialNumber.disable();
-            });
+            newItemForm.controls.receiverType.disable();
+            newItemForm.controls.manufacturerSerialNumber.disable();
         });
     }
 }

--- a/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
+++ b/src/client/app/shared/abstract-groups-items/abstract-group.component.ts
@@ -211,6 +211,30 @@ export abstract class AbstractGroupComponent<T extends AbstractViewModel>
     }
 
     /**
+     * Add a new GNSS Receiver by copying and updating values from the current one
+     */
+    addNewByCopying(event: UIEvent) {
+        if (!this.hasItems()) {
+            return;
+        }
+
+        this.addNew(event);
+
+        setTimeout(() => {
+            let newItemForm = <FormGroup>this.parentForm.at(0);
+            let currentItemForm = <FormGroup>this.parentForm.at(1);
+            this.copyValuesFromCurrentItem(newItemForm, currentItemForm);
+        });
+    }
+
+    /**
+     * Copy values from the current item to the new item created, and disable key fields if required.
+     *
+     * Note: cannot declare as an abstract method as not all child components will implement the Update function
+     */
+    copyValuesFromCurrentItem(newItemForm: FormGroup, currentItemForm: FormGroup): void {}
+
+    /**
      * Setup the form for the group.  It will contain an array of Items.
      *
      * @param itemsArrayName that is set on the parentForm


### PR DESCRIPTION
The purpose of this refactoring is to make addNewByCopying() to be a generic method so that it can be used by other instrumental components (such as GNSS Antenna) when implement the update function.