### PR TITLE
Fix error of loading ngx-bootstrap-ga when running unit tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -74,6 +74,7 @@ module.exports = function (config) {
       // suppress annoying 404 warnings for resources, images, etc.
       { pattern: 'dist/dev/assets/**/*', watched: false, included: false, served: true },
 
+      { pattern: 'node_modules/ngx-bootstrap-ga/**/*.js', included: false, watched: false },  // for typeahead
       { pattern: 'node_modules/ng2-bootstrap/**/*.js', included: false, watched: false },
       { pattern: 'node_modules/ng2-validation/bundles/ng2-validation.umd.js', included: false, watched: false },
       { pattern: 'node_modules/libphonenumber-js/bundle/libphonenumber-js.min.js', included: false, watched: false },

--- a/tools/config/project.config.ts
+++ b/tools/config/project.config.ts
@@ -66,6 +66,10 @@ export class ProjectConfig extends SeedConfig {
     // Add packages (e.g. ng2-translate)
     let additionalPackages: ExtendPackages[] = [
       {
+        name: 'ngx-bootstrap-ga',
+        path: 'node_modules/ngx-bootstrap-ga/bundles/ngx-bootstrap.umd.min.js'
+      },
+      {
         name: 'ng2-bootstrap',
         path: 'node_modules/ng2-bootstrap/bundles/ng2-bootstrap.umd.min.js'
       },


### PR DESCRIPTION
The error messages are:

 404: /base/node_modules/ngx-bootstrap-ga/bundles/ngx-bootstrap.umd.min.js
Chromium 62.0.3202 (Ubuntu 0.0.0) ERROR: '(SystemJS) XHR error (404 Not Found) loading http://localhost:9876/base/node_modules/ngx-bootstrap-ga/bundles/ngx-bootstrap.umd.min.js
	Error: XHR error (404 Not Found) loading http://localhost:9876/base/node_modules/ngx-bootstrap-ga/bundles/ngx-bootstrap.umd.min.js
	    at XMLHttpRequest.wrapFn (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:1332:39)
	    at ZoneDelegate.invokeTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:423:31)
	    at Zone.runTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:195:47)
	    at ZoneTask.invokeTask [as invoke] (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:498:34)
	    at invokeTask (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:1744:14)
	    at XMLHttpRequest.globalZoneAwareCallback (http://localhost:9876/base/node_modules/zone.js/dist/zone.js?1c31e1573f39eb8833492ad623429d4387fa6d21:1770:17)
	Error loading http://localhost:9876/base/node_modules/ngx-bootstrap-ga/bundles/ngx-bootstrap.umd.min.js as "ngx-bootstrap-ga" from http://localhost:9876/base/dist/dev/app/shared/form-input/form-input.module.js'