### PR TITLE
Upgrade node version to 6.17.1 to fix error of missing required argument #1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: node_js
-node_js: 6.4.0
+node_js: 6.17.1
 
 install: true  # yarn bug
 


### PR DESCRIPTION
The node version currently used is v6.4.0 which was released on 2016-08-12. It appears something was released that breaks older versions of node and npm:

```
npm ERR! typeerror Error: Missing required argument #1
npm ERR! typeerror     at andLogAndFinish (/home/travis/.nvm/versions/node/v6.4.0/lib/node_modules/npm/lib/fetch-package-metadata.js:31:3)
```
See [https://travis-ci.org/github/GeoscienceAustralia/GNSS-Site-Manager/builds/707577678](https://travis-ci.org/github/GeoscienceAustralia/GNSS-Site-Manager/builds/707577678)

Upgrading node version to v6.17.1 (released on 2019-04-03) seems to be able to fix this issue.
